### PR TITLE
bugfix: Fix the issue where the panel's bottom is obscured in fullscr…

### DIFF
--- a/packages/suite-base/src/components/PanelRoot.tsx
+++ b/packages/suite-base/src/components/PanelRoot.tsx
@@ -73,7 +73,7 @@ const useStyles = makeStyles<Omit<PanelRootProps, "fullscreenState" | "selected"
       top: APP_BAR_HEIGHT, // offset by app bar height
       left: 0,
       right: 0,
-      bottom: 77, // match PlaybackBar height
+      bottom: 86, // match PlaybackBar height
       zIndex: 10000,
       transition: transitions.create(["border-width", "top", "right", "bottom", "left"], {
         duration, // match to timeout duration inside Panel component

--- a/packages/suite-base/src/components/PlaybackControls/index.tsx
+++ b/packages/suite-base/src/components/PlaybackControls/index.tsx
@@ -59,7 +59,7 @@ const useStyles = makeStyles()((theme) => ({
   root: {
     display: "flex",
     flexDirection: "column",
-    padding: theme.spacing(0.5, 1, 1, 1),
+    padding: theme.spacing(0.5, 1, 0.5, 1),
     position: "relative",
     backgroundColor: theme.palette.background.paper,
     borderTop: `1px solid ${theme.palette.divider}`,


### PR DESCRIPTION
Fix the issue where the panel's bottom is obscured in fullscreen mode.

**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
