### PR TITLE
Fix linux build

### DIFF
--- a/packages/suite-desktop/src/afterPack.ts
+++ b/packages/suite-desktop/src/afterPack.ts
@@ -4,7 +4,7 @@
 
 import { exec } from "@actions/exec";
 import { downloadTool, extractZip } from "@actions/tool-cache";
-import type MacPackager from "app-builder-lib/out/macPackager";
+import type { MacPackager } from "app-builder-lib/out/macPackager";
 import { log, Arch } from "builder-util";
 import crypto from "crypto";
 import { AfterPackContext } from "electron-builder";


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
FIxes this issues when running `yarn run package:linux`
```
  ⨯ Unable to `require`  moduleName=/home/e/workspace/flora/packages/suite-desktop/src/afterPack.ts message=⨯ Unable to compile TypeScript:
packages/suite-desktop/src/afterPack.ts:7:1 - error TS6133: 'MacPackager' is declared but its value is never read.
                           7 import type MacPackager from "app-builder-lib/out/macPackager";
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
packages/suite-desktop/src/afterPack.ts:16:54 - error TS2709: Cannot use namespace 'MacPackager' as a type.
                           16   const macPackager = context.packager as unknown as MacPackager;
```

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
