### PR TITLE
Fix Warning: Received `true` for a non-boolean attribute `flex-grow-0`.

### DIFF
--- a/packages/suite-base/src/components/AppBar/NestedMenuItem.tsx
+++ b/packages/suite-base/src/components/AppBar/NestedMenuItem.tsx
@@ -56,9 +56,11 @@ export function NestedMenuItem(
               >
                 {item.icon != undefined ? <ListItemIcon>{item.icon}</ListItemIcon> : ReactNull}
                 <ListItemText>{item.label}</ListItemText>
-                {item.shortcut && <Typography flex-grow-0 variant="body2">
-                  <kbd>{item.shortcut}</kbd>
-                </Typography>}
+                {item.shortcut && (
+                  <Typography sx={{ flexGrow: 0 }} variant="body2">
+                    <kbd>{item.shortcut}</kbd>
+                  </Typography>
+                )}
               </MenuItem>
             );
           case "divider":


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
Fix this error
Warning: Received `true` for a non-boolean attribute `flex-grow-0`.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
