### PR TITLE
Fix typo in macOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Flora is an integrated visualization and diagnosis tool for robotics, available 
 ### macos
 
 ```shell
-brow tab flora-suite/homebrew-flora
+brew tap flora-suite/homebrew-flora
 brew install flora
 ```
 


### PR DESCRIPTION
**User-Facing Changes**
Fix typo in the Homebrew instruction to install on Mac

**Description**
As described above

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] This change is covered by unit tests
