### PR TITLE
fix: align language setting with detected locale

### DIFF
--- a/packages/suite-base/src/components/AppSettingsDialog/settings.test.ts
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.test.ts
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { getSupportedLanguage } from "./settings";
+
+describe("getSupportedLanguage", () => {
+  it.each([
+    ["en", "en"],
+    ["en-US", "en"],
+    ["zh-CN", "zh"],
+    ["ja-JP", "ja"],
+    ["fr-FR", "en"],
+    [undefined, "en"],
+  ])("maps %s to %s", (language, expectedLanguage) => {
+    expect(getSupportedLanguage(language)).toEqual(expectedLanguage);
+  });
+});

--- a/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/suite-base/src/components/AppSettingsDialog/settings.tsx
@@ -47,6 +47,11 @@ const LANGUAGE_OPTIONS: { key: Language; value: string }[] = [
   { key: "ja", value: "日本語" },
 ];
 
+export function getSupportedLanguage(language: string | undefined): Language {
+  const languageCode = language?.split(/[-_]/)[0];
+  return LANGUAGE_OPTIONS.find(({ key }) => key === languageCode)?.key ?? "en";
+}
+
 const useStyles = makeStyles()((theme) => ({
   autocompleteInput: {
     "&.MuiOutlinedInput-input": {
@@ -352,9 +357,10 @@ export function RosPackagePath(): React.ReactElement {
 
 export function LanguageSettings(): React.ReactElement {
   const { t, i18n } = useTranslation("appSettings");
-  const [selectedLanguage = "en", setSelectedLanguage] = useAppConfigurationValue<Language>(
+  const [configuredLanguage, setSelectedLanguage] = useAppConfigurationValue<Language>(
     AppSetting.LANGUAGE,
   );
+  const selectedLanguage = configuredLanguage ?? getSupportedLanguage(i18n.resolvedLanguage);
   const onChangeLanguage = useCallback(
     (event: SelectChangeEvent<Language>) => {
       const lang = event.target.value;


### PR DESCRIPTION
## Summary
- show the detected UI locale in Settings when no language preference is saved
- preserve explicit language preferences and normalize regional locale codes
- cover supported and fallback locale mapping

## Testing
- yarn test packages/suite-base/src/components/AppSettingsDialog/settings.test.ts --runInBand
- yarn prettier --check packages/suite-base/src/components/AppSettingsDialog/settings.tsx packages/suite-base/src/components/AppSettingsDialog/settings.test.ts
- yarn eslint --report-unused-disable-directives --config .eslintrc.ci.yaml packages/suite-base/src/components/AppSettingsDialog/settings.tsx packages/suite-base/src/components/AppSettingsDialog/settings.test.ts *(reports four pre-existing errors in settings.tsx)*