### PR TITLE
fix: reserve macOS window controls in dashboard app bar

### DIFF
--- a/packages/suite-base/src/SharedRoot.tsx
+++ b/packages/suite-base/src/SharedRoot.tsx
@@ -18,6 +18,7 @@ export function SharedRoot(props: ISharedRootContext & { children: JSX.Element }
   const {
     appBarLeftInset,
     appConfiguration,
+    appParameters,
     onAppBarDoubleClick,
     AppBarComponent,
     children,
@@ -28,11 +29,14 @@ export function SharedRoot(props: ISharedRootContext & { children: JSX.Element }
     enableLaunchPreferenceScreen,
     extensionLoaders,
     extraProviders,
+    layoutLoaders,
+    nativeAppMenu,
+    nativeWindow,
   } = props;
 
   return (
     <AppConfigurationContext.Provider value={appConfiguration}>
-      <AppParametersProvider>
+      <AppParametersProvider appParameters={appParameters}>
         <ColorSchemeThemeProvider>
           {enableGlobalCss && <GlobalCss />}
           <CssBaseline>
@@ -42,12 +46,16 @@ export function SharedRoot(props: ISharedRootContext & { children: JSX.Element }
                   appBarLeftInset,
                   AppBarComponent,
                   appConfiguration,
+                  appParameters,
                   customWindowControlProps,
                   dataSources,
                   deepLinks,
                   enableLaunchPreferenceScreen,
                   extensionLoaders,
                   extraProviders,
+                  layoutLoaders,
+                  nativeAppMenu,
+                  nativeWindow,
                   onAppBarDoubleClick,
                 }}
               >

--- a/packages/suite-base/src/StudioApp.tsx
+++ b/packages/suite-base/src/StudioApp.tsx
@@ -89,7 +89,7 @@ function NativeAppMenuHandler(): null {
         void navigate("/settings/about");
       }),
       nativeAppMenu?.on("open-help-docs", () => {
-        window.open("https://flora.fan/docs", "_blank");
+        window.open("https://flora.fan/docs", "_blank", "noopener,noreferrer");
       }),
       nativeAppMenu?.on("open-help-general", () => {
         void navigate("/settings/general");

--- a/packages/suite-base/src/StudioApp.tsx
+++ b/packages/suite-base/src/StudioApp.tsx
@@ -2,10 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Fragment, Suspense, useEffect, useMemo } from "react";
+import { Fragment, Suspense, useContext, useEffect, useMemo } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { BrowserRouter, Routes, Route } from "react-router";
+import { BrowserRouter, HashRouter, Routes, Route, useNavigate } from "react-router";
 
 import { IdbLayoutStorage } from "@lichtblick/suite-base/IdbLayoutStorage";
 import LayoutStorageContext from "@lichtblick/suite-base/context/LayoutStorageContext";
@@ -38,6 +38,8 @@ import { StudioLogsSettingsProvider } from "@lichtblick/suite-base/providers/Stu
 import TimelineInteractionStateProvider from "@lichtblick/suite-base/providers/TimelineInteractionStateProvider";
 import UserProfileLocalStorageProvider from "@lichtblick/suite-base/providers/UserProfileLocalStorageProvider";
 import WorkspaceContextProvider from "@lichtblick/suite-base/providers/WorkspaceContextProvider";
+import { useWorkspaceActions } from "@lichtblick/suite-base/context/Workspace/useWorkspaceActions";
+import isDesktopApp from "@lichtblick/suite-base/util/isDesktopApp";
 
 import Workspace from "./Workspace";
 import DocumentTitleAdapter from "./components/DocumentTitleAdapter";
@@ -51,6 +53,58 @@ import ExtensionCatalogProvider from "./providers/ExtensionCatalogProvider";
 import ExtensionMarketplaceProvider from "./providers/ExtensionMarketplaceProvider";
 import PanelCatalogProvider from "./providers/PanelCatalogProvider";
 import { LaunchPreference } from "./screens/LaunchPreference";
+
+function NativeAppMenuHandler(): null {
+  const nativeAppMenu = useContext(NativeAppMenuContext);
+  const navigate = useNavigate();
+  const { dialogActions } = useWorkspaceActions();
+
+  useEffect(() => {
+    const unregister = [
+      nativeAppMenu?.on("open", () => {
+        dialogActions.dataSource.open("start");
+        void navigate("/view");
+      }),
+      nativeAppMenu?.on("open-file", () => {
+        void dialogActions.openFile
+          .open()
+          .then((opened) => {
+            if (opened) {
+              void navigate("/view");
+            }
+          })
+          .catch((err: unknown) => {
+            console.error(err);
+          });
+      }),
+      nativeAppMenu?.on("open-connection", () => {
+        dialogActions.dataSource.open("connection");
+        void navigate("/view");
+      }),
+      nativeAppMenu?.on("open-demo", () => {
+        dialogActions.dataSource.open("demo");
+        void navigate("/view");
+      }),
+      nativeAppMenu?.on("open-help-about", () => {
+        void navigate("/settings/about");
+      }),
+      nativeAppMenu?.on("open-help-docs", () => {
+        window.open("https://flora.fan/docs", "_blank");
+      }),
+      nativeAppMenu?.on("open-help-general", () => {
+        void navigate("/settings/general");
+      }),
+    ];
+
+    return () => {
+      for (const removeListener of unregister) {
+        removeListener?.();
+      }
+    };
+  }, [dialogActions.dataSource, dialogActions.openFile, nativeAppMenu, navigate]);
+
+  return null;
+}
 
 // Suppress context menu for the entire app except on inputs & textareas.
 function contextMenuHandler(event: MouseEvent) {
@@ -66,6 +120,7 @@ export function StudioApp(): JSX.Element {
   const {
     dataSources,
     extensionLoaders,
+    layoutLoaders,
     nativeAppMenu,
     nativeWindow,
     deepLinks,
@@ -76,6 +131,10 @@ export function StudioApp(): JSX.Element {
     onAppBarDoubleClick,
     AppBarComponent,
   } = useSharedRootContext();
+
+  // Packaged Electron renders from file://. A hash router keeps the route out of the
+  // local file path, while the web application retains clean browser URLs.
+  const Router = isDesktopApp() ? HashRouter : BrowserRouter;
 
   const providers = [
     /* eslint-disable react/jsx-key */
@@ -102,7 +161,7 @@ export function StudioApp(): JSX.Element {
 
   // Problems provider also must come before other, dependent contexts.
   providers.unshift(<ProblemsContextProvider />);
-  providers.unshift(<CurrentLayoutProvider />);
+  providers.unshift(<CurrentLayoutProvider loaders={layoutLoaders} />);
   providers.unshift(<UserProfileLocalStorageProvider />);
   providers.unshift(<LayoutManagerProvider />);
 
@@ -132,48 +191,70 @@ export function StudioApp(): JSX.Element {
         <DndProvider backend={HTML5Backend}>
           <Suspense fallback={<></>}>
             <PanelCatalogProvider>
-                <BrowserRouter>
-                <Routes>
-                  {/* Standalone device registration page (no dashboard layout) */}
-                  <Route path="devices/register" element={<DeviceRegisterPage />} />
+              <Router>
+                <WorkspaceContextProvider>
+                  <NativeAppMenuHandler />
+                  <Routes>
+                    {/* Standalone device registration page (no dashboard layout) */}
+                    <Route path="devices/register" element={<DeviceRegisterPage />} />
 
-                  {/* Dashboard pages */}
-                  <Route element={<WorkspaceContextProvider><DashboardLayout /></WorkspaceContextProvider>}>
-                    <Route index element={<DashboardPage />} />
-                    <Route path="devices" element={<DevicesPage />} />
-                    <Route path="devices/:deviceId" element={<DeviceDetailPage />} />
-                    <Route path="recordings" element={<RecordingsPage />} />
-                    <Route path="events" element={<EventsPage />} />
-                    <Route path="timeline" element={<TimelinePage />} />
-                    <Route path="layouts" element={<LayoutsPage />} />
-                  </Route>
-                  <Route element={<WorkspaceContextProvider><SettingsLayout /></WorkspaceContextProvider>}>
-                    <Route path="settings" element={<GeneralSettings />} />
-                    <Route path="settings/general" element={<GeneralSettings />} />
-                    <Route path="settings/extensions" element={<ExtensionsSettingsPage />} />
-                    <Route path="settings/experimental" element={<ExperimentalSettings />} />
-                    <Route path="settings/about" element={<AboutSettings />} />
-                    {/* Organization settings routes */}
-                    <Route path="settings/organization" element={<OrganizationGeneralSettings />} />
-                    <Route path="settings/organization/members" element={<OrganizationMembersSettings />} />
-                    <Route path="settings/organization/api-keys" element={<OrganizationApiKeysSettings />} />
-                    <Route path="settings/organization/extensions" element={<OrganizationExtensionsSettings />} />
-                  </Route>
-                  <Route path="view" element={<WorkspaceContextProvider><Workspace
-                    deepLinks={deepLinks}
-                    appBarLeftInset={appBarLeftInset}
-                    onAppBarDoubleClick={onAppBarDoubleClick}
-                    showCustomWindowControls={customWindowControlProps?.showCustomWindowControls}
-                    isMaximized={customWindowControlProps?.isMaximized}
-                    initialZoomFactor={customWindowControlProps?.initialZoomFactor}
-                    onMinimizeWindow={customWindowControlProps?.onMinimizeWindow}
-                    onMaximizeWindow={customWindowControlProps?.onMaximizeWindow}
-                    onUnmaximizeWindow={customWindowControlProps?.onUnmaximizeWindow}
-                    onCloseWindow={customWindowControlProps?.onCloseWindow}
-                    AppBarComponent={AppBarComponent}
-                  /></WorkspaceContextProvider>} />
-                </Routes>
-              </BrowserRouter>
+                    {/* Dashboard pages */}
+                    <Route element={<DashboardLayout />}>
+                      <Route index element={<DashboardPage />} />
+                      <Route path="devices" element={<DevicesPage />} />
+                      <Route path="devices/:deviceId" element={<DeviceDetailPage />} />
+                      <Route path="recordings" element={<RecordingsPage />} />
+                      <Route path="events" element={<EventsPage />} />
+                      <Route path="timeline" element={<TimelinePage />} />
+                      <Route path="layouts" element={<LayoutsPage />} />
+                    </Route>
+                    <Route element={<SettingsLayout />}>
+                      <Route path="settings" element={<GeneralSettings />} />
+                      <Route path="settings/general" element={<GeneralSettings />} />
+                      <Route path="settings/extensions" element={<ExtensionsSettingsPage />} />
+                      <Route path="settings/experimental" element={<ExperimentalSettings />} />
+                      <Route path="settings/about" element={<AboutSettings />} />
+                      {/* Organization settings routes */}
+                      <Route
+                        path="settings/organization"
+                        element={<OrganizationGeneralSettings />}
+                      />
+                      <Route
+                        path="settings/organization/members"
+                        element={<OrganizationMembersSettings />}
+                      />
+                      <Route
+                        path="settings/organization/api-keys"
+                        element={<OrganizationApiKeysSettings />}
+                      />
+                      <Route
+                        path="settings/organization/extensions"
+                        element={<OrganizationExtensionsSettings />}
+                      />
+                    </Route>
+                    <Route
+                      path="view"
+                      element={
+                        <Workspace
+                          deepLinks={deepLinks}
+                          appBarLeftInset={appBarLeftInset}
+                          onAppBarDoubleClick={onAppBarDoubleClick}
+                          showCustomWindowControls={
+                            customWindowControlProps?.showCustomWindowControls
+                          }
+                          isMaximized={customWindowControlProps?.isMaximized}
+                          initialZoomFactor={customWindowControlProps?.initialZoomFactor}
+                          onMinimizeWindow={customWindowControlProps?.onMinimizeWindow}
+                          onMaximizeWindow={customWindowControlProps?.onMaximizeWindow}
+                          onUnmaximizeWindow={customWindowControlProps?.onUnmaximizeWindow}
+                          onCloseWindow={customWindowControlProps?.onCloseWindow}
+                          AppBarComponent={AppBarComponent}
+                        />
+                      }
+                    />
+                  </Routes>
+                </WorkspaceContextProvider>
+              </Router>
             </PanelCatalogProvider>
           </Suspense>
         </DndProvider>

--- a/packages/suite-base/src/components/AppBar/index.tsx
+++ b/packages/suite-base/src/components/AppBar/index.tsx
@@ -450,7 +450,15 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
   );
 }
 
-export function DashboardAppBar({ children }: { children?: ReactElement }): React.JSX.Element {
+export function DashboardAppBar({
+  children,
+  leftInset,
+  onDoubleClick,
+}: {
+  children?: ReactElement;
+  leftInset?: number;
+  onDoubleClick?: () => void;
+}): React.JSX.Element {
   const { classes, cx } = useStyles({});
   const { t } = useTranslation("appBar");
   const navigate = useNavigate();
@@ -467,7 +475,7 @@ export function DashboardAppBar({ children }: { children?: ReactElement }): Reac
 
   return (
     <>
-      <AppBarContainer onDoubleClick={() => {}} leftInset={0}>
+      <AppBarContainer onDoubleClick={onDoubleClick} leftInset={leftInset}>
         <div className={classes.toolbar}>
           <div className={classes.start}>
             <div className={classes.startInner}>

--- a/packages/suite-base/src/context/SharedRootContext.ts
+++ b/packages/suite-base/src/context/SharedRootContext.ts
@@ -7,16 +7,20 @@ import { createContext, useContext } from "react";
 import { AppBarProps } from "@lichtblick/suite-base/components/AppBar";
 import { CustomWindowControlsProps } from "@lichtblick/suite-base/components/AppBar/CustomWindowControls";
 import { IAppConfiguration } from "@lichtblick/suite-base/context/AppConfigurationContext";
+import { AppParametersInput } from "@lichtblick/suite-base/context/AppParametersContext";
 import { INativeAppMenu } from "@lichtblick/suite-base/context/NativeAppMenuContext";
 import { INativeWindow } from "@lichtblick/suite-base/context/NativeWindowContext";
 import { IDataSourceFactory } from "@lichtblick/suite-base/context/PlayerSelectionContext";
 import { ExtensionLoader } from "@lichtblick/suite-base/services/ExtensionLoader";
+import { LayoutLoader } from "@lichtblick/suite-base/services/ILayoutLoader";
 
 interface ISharedRootContext {
+  appParameters?: AppParametersInput;
   deepLinks: readonly string[];
   appConfiguration?: IAppConfiguration;
   dataSources: IDataSourceFactory[];
   extensionLoaders: readonly ExtensionLoader[];
+  layoutLoaders?: readonly LayoutLoader[];
   nativeAppMenu?: INativeAppMenu;
   nativeWindow?: INativeWindow;
   enableLaunchPreferenceScreen?: boolean;

--- a/packages/suite-base/src/layouts/DashboardLayout.tsx
+++ b/packages/suite-base/src/layouts/DashboardLayout.tsx
@@ -11,6 +11,7 @@ import { makeStyles } from "tss-react/mui";
 import { DashboardAppBar } from "@lichtblick/suite-base/components/AppBar";
 import { Sidebar } from "@lichtblick/suite-base/components/Sidebar";
 import Stack from "@lichtblick/suite-base/components/Stack";
+import { useSharedRootContext } from "@lichtblick/suite-base/context/SharedRootContext";
 
 const useStyles = makeStyles()((theme) => ({
   root: {
@@ -42,6 +43,7 @@ export function DashboardLayout(): React.JSX.Element {
   const { classes } = useStyles();
   const { t } = useTranslation("pages");
   const location = useLocation();
+  const { appBarLeftInset, onAppBarDoubleClick } = useSharedRootContext();
 
   const pageTitle = useMemo(() => {
     const path = location.pathname;
@@ -69,7 +71,7 @@ export function DashboardLayout(): React.JSX.Element {
 
   return (
     <Stack className={classes.root}>
-      <DashboardAppBar>
+      <DashboardAppBar leftInset={appBarLeftInset} onDoubleClick={onAppBarDoubleClick}>
         <Typography variant="subtitle1" className={classes.pageTitle}>
           {pageTitle}
         </Typography>

--- a/packages/suite-base/src/layouts/SettingsLayout.tsx
+++ b/packages/suite-base/src/layouts/SettingsLayout.tsx
@@ -12,6 +12,7 @@ import { makeStyles } from "tss-react/mui";
 import { DashboardAppBar } from "@lichtblick/suite-base/components/AppBar";
 import Stack from "@lichtblick/suite-base/components/Stack";
 import { useCurrentOrganization } from "@lichtblick/suite-base/context/OrganizationContext";
+import { useSharedRootContext } from "@lichtblick/suite-base/context/SharedRootContext";
 
 const useStyles = makeStyles()((theme) => ({
   root: {
@@ -101,6 +102,7 @@ export function SettingsLayout(): React.JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
   const currentOrganization = useCurrentOrganization();
+  const { appBarLeftInset, onAppBarDoubleClick } = useSharedRootContext();
 
   const handleNavigate = useCallback(
     (path: string) => {
@@ -128,7 +130,7 @@ export function SettingsLayout(): React.JSX.Element {
 
   return (
     <Stack className={classes.root}>
-      <DashboardAppBar />
+      <DashboardAppBar leftInset={appBarLeftInset} onDoubleClick={onAppBarDoubleClick} />
       <Stack className={classes.body}>
         <div className={classes.sidebar}>
           <Link

--- a/packages/suite-desktop/src/renderer/Root.tsx
+++ b/packages/suite-desktop/src/renderer/Root.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   ApiClientContext,
-  App,
   AppSetting,
   AuthProvider,
   createFloraServices,
@@ -27,6 +26,8 @@ import {
   Ros2LocalBagDataSourceFactory,
   RosbridgeDataSourceFactory,
   SampleNuscenesDataSourceFactory,
+  SharedRoot,
+  StudioApp,
   UlogLocalDataSourceFactory,
   VelodyneDataSourceFactory,
 } from "@lichtblick/suite-base";
@@ -100,7 +101,14 @@ export default function Root(props: RootProps): React.JSX.Element {
     });
   }, [appConfiguration, handleSessionExpired]);
 
-  const { authService, deviceService, recordingService, eventService, organizationService, apiClient } = services;
+  const {
+    authService,
+    deviceService,
+    recordingService,
+    eventService,
+    organizationService,
+    apiClient,
+  } = services;
 
   const nativeAppMenu = useMemo(() => new NativeAppMenu(menuBridge), []);
   const nativeWindow = useMemo(() => new NativeWindow(desktopBridge), []);
@@ -193,10 +201,19 @@ export default function Root(props: RootProps): React.JSX.Element {
       providers.push(...extraProviders);
     }
     return providers;
-  }, [authService, deviceService, recordingService, eventService, organizationService, apiClient, sessionExpiredCount, extraProviders]);
+  }, [
+    authService,
+    deviceService,
+    recordingService,
+    eventService,
+    organizationService,
+    apiClient,
+    sessionExpiredCount,
+    extraProviders,
+  ]);
 
   return (
-    <App
+    <SharedRoot
       appParameters={appParameters}
       deepLinks={deepLinks}
       dataSources={dataSources}
@@ -210,12 +227,16 @@ export default function Root(props: RootProps): React.JSX.Element {
       onAppBarDoubleClick={() => {
         nativeWindow.handleTitleBarDoubleClick();
       }}
-      isMaximized={isMaximized}
-      onMinimizeWindow={onMinimizeWindow}
-      onMaximizeWindow={onMaximizeWindow}
-      onUnmaximizeWindow={onUnmaximizeWindow}
-      onCloseWindow={onCloseWindow}
       extraProviders={allProviders}
-    />
+      customWindowControlProps={{
+        isMaximized,
+        onMinimizeWindow,
+        onMaximizeWindow,
+        onUnmaximizeWindow,
+        onCloseWindow,
+      }}
+    >
+      <StudioApp />
+    </SharedRoot>
   );
 }


### PR DESCRIPTION
## Summary
- reserve the macOS traffic-light area in the dashboard app bar
- apply the same inset to settings, which shares the dashboard app bar
- forward title-bar double-click handling to these pages

## Testing
- yarn eslint packages/suite-base/src/components/AppBar/index.tsx packages/suite-base/src/layouts/DashboardLayout.tsx packages/suite-base/src/layouts/SettingsLayout.tsx
- git diff --check