### PR TITLE
fix: restore recent local files after refresh

### DIFF
--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -524,7 +524,7 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
       }
 
       log.debug("Initialising recent source from url", recentId);
-      selectRecent(recentId);
+      selectRecent(recentId, { requestPermission: false });
       setUnappliedSourceArgs({ ds: undefined, dsParams: undefined });
       return;
     }

--- a/packages/suite-base/src/Workspace.tsx
+++ b/packages/suite-base/src/Workspace.tsx
@@ -151,7 +151,8 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
   const { PerformanceSidebarComponent } = useAppContext();
   const { classes } = useStyles();
   const containerRef = useRef<HTMLDivElement>(ReactNull);
-  const { availableSources, selectSource } = usePlayerSelection();
+  const { availableSources, selectRecent, selectSource, recentSourcesLoading } =
+    usePlayerSelection();
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const playerProblems = useMessagePipeline(selectPlayerProblems);
 
@@ -515,6 +516,19 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
       return;
     }
 
+    const recentId = unappliedSourceArgs.dsParams?.recentId;
+    if (recentId != undefined) {
+      // Wait until IndexedDB has restored the persisted file handles before selecting the recent.
+      if (recentSourcesLoading === true) {
+        return;
+      }
+
+      log.debug("Initialising recent source from url", recentId);
+      selectRecent(recentId);
+      setUnappliedSourceArgs({ ds: undefined, dsParams: undefined });
+      return;
+    }
+
     // Apply any available data source args
     if (unappliedSourceArgs.ds) {
       log.debug("Initialising source from url", unappliedSourceArgs);
@@ -525,7 +539,14 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
       selectEvent(unappliedSourceArgs.dsParams?.eventId);
       setUnappliedSourceArgs({ ds: undefined, dsParams: undefined });
     }
-  }, [selectEvent, selectSource, unappliedSourceArgs, setUnappliedSourceArgs]);
+  }, [
+    recentSourcesLoading,
+    selectEvent,
+    selectRecent,
+    selectSource,
+    unappliedSourceArgs,
+    setUnappliedSourceArgs,
+  ]);
 
   const [unappliedTime, setUnappliedTime] = useState(
     targetUrlState ? { time: targetUrlState.time } : undefined,

--- a/packages/suite-base/src/components/PlayerManager.tsx
+++ b/packages/suite-base/src/components/PlayerManager.tsx
@@ -244,6 +244,11 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
                 }
 
                 if (permission !== "granted") {
+                  if (args.requestPermission === false) {
+                    throw new Error(
+                      `Permission required to reopen ${handle.name}. Select it from Recent data sources to grant access.`,
+                    );
+                  }
                   const newPerm = await fileHandle.requestPermission({ mode: "read" });
                   if (newPerm !== "granted") {
                     throw new Error(`Permission denied: ${handle.name}`);
@@ -335,7 +340,7 @@ function createSelectRecentCallback(
   enqueueSnackbar: ReturnType<typeof useSnackbar>["enqueueSnackbar"],
   setSelectedRecentId: (recentId: string | undefined) => void,
 ) {
-  return (recentId: string) => {
+  return (recentId: string, options?: { requestPermission?: boolean }) => {
     // find the recent from the list and initialize
     const foundRecent = recents.find((value) => value.id === recentId);
     if (!foundRecent) {
@@ -358,6 +363,7 @@ function createSelectRecentCallback(
           type: "file",
           handles: foundRecent.handles,
           recentId,
+          requestPermission: options?.requestPermission,
         });
       }
     }

--- a/packages/suite-base/src/components/PlayerManager.tsx
+++ b/packages/suite-base/src/components/PlayerManager.tsx
@@ -89,7 +89,8 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   const [basePlayer, setBasePlayer] = useState<Player | undefined>();
 
-  const { recents, addRecent } = useIndexedDbRecents();
+  const { recents, addRecent, loading: recentSourcesLoading } = useIndexedDbRecents();
+  const [selectedRecentId, setSelectedRecentId] = useState<string | undefined>();
 
   const userScripts = useCurrentLayoutSelector(userScriptsSelector);
   const globalVariables = useCurrentLayoutSelector(globalVariablesSelector);
@@ -158,6 +159,10 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       }
 
       metricsCollector.setProperty("player", sourceId);
+
+      if (args?.type === "connection" || args?.files) {
+        setSelectedRecentId(undefined);
+      }
 
       setSelectedSource(foundSource);
 
@@ -256,12 +261,17 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
               });
 
               setBasePlayer(newPlayer);
-              addRecent({
-                type: "file",
-                title: mergeMultipleFileNames(handles.map((h) => h.name)),
-                sourceId: foundSource.id,
-                handles,
-              });
+              if (args.recentId != undefined) {
+                setSelectedRecentId(args.recentId);
+              } else {
+                const recent = addRecent({
+                  type: "file",
+                  title: mergeMultipleFileNames(handles.map((h) => h.name)),
+                  sourceId: foundSource.id,
+                  handles,
+                });
+                setSelectedRecentId(recent.id);
+              }
 
               return;
             }
@@ -280,7 +290,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   // necessary to pull out callback creation to avoid capturing the initial player in closure context
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const selectRecent = useCallback(
-    createSelectRecentCallback(recents, selectSource, enqueueSnackbar),
+    createSelectRecentCallback(recents, selectSource, enqueueSnackbar, setSelectedRecentId),
     [recents, enqueueSnackbar, selectSource],
   );
 
@@ -297,6 +307,8 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
     selectedSource,
     availableSources: playerSources,
     recentSources,
+    selectedRecentId,
+    recentSourcesLoading,
   };
 
   return (
@@ -321,6 +333,7 @@ function createSelectRecentCallback(
   recents: RecentRecord[],
   selectSource: (sourceId: string, dataSourceArgs: DataSourceArgs) => Promise<void>,
   enqueueSnackbar: ReturnType<typeof useSnackbar>["enqueueSnackbar"],
+  setSelectedRecentId: (recentId: string | undefined) => void,
 ) {
   return (recentId: string) => {
     // find the recent from the list and initialize
@@ -329,6 +342,8 @@ function createSelectRecentCallback(
       enqueueSnackbar(`Failed to restore recent: ${recentId}`, { variant: "error" });
       return;
     }
+
+    setSelectedRecentId(recentId);
 
     switch (foundRecent.type) {
       case "connection": {
@@ -342,6 +357,7 @@ function createSelectRecentCallback(
         void selectSource(foundRecent.sourceId, {
           type: "file",
           handles: foundRecent.handles,
+          recentId,
         });
       }
     }

--- a/packages/suite-base/src/components/PlayerManager.tsx
+++ b/packages/suite-base/src/components/PlayerManager.tsx
@@ -238,7 +238,10 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
                     mode?: "read" | "readwrite";
                   }): Promise<PermissionState>;
                 };
-                const permission = await fileHandle.queryPermission({ mode: "read" });
+                const permission =
+                  args.requestPermission === true
+                    ? await fileHandle.requestPermission({ mode: "read" })
+                    : await fileHandle.queryPermission({ mode: "read" });
                 if (!isMounted()) {
                   return;
                 }
@@ -248,6 +251,9 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
                     throw new Error(
                       `Permission required to reopen ${handle.name}. Select it from Recent data sources to grant access.`,
                     );
+                  }
+                  if (args.requestPermission === true) {
+                    throw new Error(`Permission denied: ${handle.name}`);
                   }
                   const newPerm = await fileHandle.requestPermission({ mode: "read" });
                   if (newPerm !== "granted") {
@@ -363,7 +369,7 @@ function createSelectRecentCallback(
           type: "file",
           handles: foundRecent.handles,
           recentId,
-          requestPermission: options?.requestPermission,
+          requestPermission: options?.requestPermission ?? true,
         });
       }
     }

--- a/packages/suite-base/src/context/PlayerSelectionContext.ts
+++ b/packages/suite-base/src/context/PlayerSelectionContext.ts
@@ -85,6 +85,8 @@ type FileDataSourceArgs = {
   handles?: FileSystemFileHandle[]; // foxglove-depcheck-used: @types/wicg-file-system-access
   /** Existing recent record that supplied the handles. */
   recentId?: string;
+  /** Whether this selection may prompt the user to grant file access. */
+  requestPermission?: boolean;
 };
 
 type ConnectionDataSourceArgs = {
@@ -99,7 +101,7 @@ export type DataSourceArgs = FileDataSourceArgs | ConnectionDataSourceArgs;
  */
 export interface PlayerSelection {
   selectSource: (sourceId: string, args?: DataSourceArgs) => void;
-  selectRecent: (recentId: string) => void;
+  selectRecent: (recentId: string, options?: { requestPermission?: boolean }) => void;
 
   /** Currently selected data source */
   selectedSource?: IDataSourceFactory;

--- a/packages/suite-base/src/context/PlayerSelectionContext.ts
+++ b/packages/suite-base/src/context/PlayerSelectionContext.ts
@@ -83,6 +83,8 @@ type FileDataSourceArgs = {
   type: "file";
   files?: File[];
   handles?: FileSystemFileHandle[]; // foxglove-depcheck-used: @types/wicg-file-system-access
+  /** Existing recent record that supplied the handles. */
+  recentId?: string;
 };
 
 type ConnectionDataSourceArgs = {
@@ -107,6 +109,12 @@ export interface PlayerSelection {
 
   /** Recently selected sources */
   recentSources: readonly RecentSource[];
+
+  /** The active recent source, when it was opened from a persisted file handle. */
+  selectedRecentId?: string;
+
+  /** Whether persisted recent sources are still being loaded. */
+  recentSourcesLoading?: boolean;
 }
 
 const PlayerSelectionContext = createContext<PlayerSelection>({
@@ -114,6 +122,7 @@ const PlayerSelectionContext = createContext<PlayerSelection>({
   selectRecent: () => {},
   availableSources: [],
   recentSources: [],
+  recentSourcesLoading: false,
 });
 PlayerSelectionContext.displayName = "PlayerSelectionContext";
 

--- a/packages/suite-base/src/hooks/useIndexedDbRecents.ts
+++ b/packages/suite-base/src/hooks/useIndexedDbRecents.ts
@@ -54,7 +54,10 @@ interface IRecentsStore {
   recents: RecentRecord[];
 
   // Add a new recent
-  addRecent: (newRecent: UnsavedRecentRecord) => void;
+  addRecent: (newRecent: UnsavedRecentRecord) => RecentRecord;
+
+  // Whether persisted recents have finished loading.
+  loading: boolean;
 
   // Save changes
   save: () => Promise<void>;
@@ -159,6 +162,7 @@ function useIndexedDbRecents(): IRecentsStore {
       };
       newRecentsRef.current.unshift(fullRecord);
       void save();
+      return fullRecord;
     },
     [save],
   );
@@ -167,9 +171,10 @@ function useIndexedDbRecents(): IRecentsStore {
     return {
       recents,
       addRecent,
+      loading,
       save,
     };
-  }, [addRecent, recents, save]);
+  }, [addRecent, loading, recents, save]);
 }
 
 export default useIndexedDbRecents;

--- a/packages/suite-base/src/hooks/useIndexedDbRecents.ts
+++ b/packages/suite-base/src/hooks/useIndexedDbRecents.ts
@@ -64,19 +64,20 @@ interface IRecentsStore {
 }
 
 function useIndexedDbRecents(): IRecentsStore {
-  const { value: initialRecents, loading } = useAsync(
+  const { value: initialRecents, loading: initialRecentsLoading } = useAsync(
     async () => await idbGet<(RecentRecord & OldRecentRecord)[] | undefined>(IDB_KEY, IDB_STORE),
     [],
   );
 
   const [recents, setRecents] = useState<RecentRecord[]>([]);
+  const [recentsLoaded, setRecentsLoaded] = useState(false);
 
   // Track new recents in a ref and update the state after persisting
   const newRecentsRef = useRef<RecentRecord[]>([]);
 
   const save = useCallback(async () => {
     // We don't save until we've loaded our existing recents. This ensures we include stored recents when we save
-    if (loading) {
+    if (initialRecentsLoading) {
       return;
     }
 
@@ -124,11 +125,11 @@ function useIndexedDbRecents(): IRecentsStore {
     idbSet(IDB_KEY, recentsToSave, IDB_STORE).catch((err) => {
       log.error(err);
     });
-  }, [loading]);
+  }, [initialRecentsLoading]);
 
   // Set the first load records from the store to the state
   useLayoutEffect(() => {
-    if (loading) {
+    if (initialRecentsLoading) {
       return;
     }
 
@@ -152,7 +153,8 @@ function useIndexedDbRecents(): IRecentsStore {
       // Normally a save invokes set - but since we don't need to save we set here
       setRecents(newRecentsRef.current);
     }
-  }, [loading, initialRecents, save]);
+    setRecentsLoaded(true);
+  }, [initialRecentsLoading, initialRecents, save]);
 
   const addRecent = useCallback(
     (record: UnsavedRecentRecord) => {
@@ -171,10 +173,10 @@ function useIndexedDbRecents(): IRecentsStore {
     return {
       recents,
       addRecent,
-      loading,
+      loading: !recentsLoaded,
       save,
     };
-  }, [addRecent, loading, recents, save]);
+  }, [addRecent, recents, recentsLoaded, save]);
 }
 
 export default useIndexedDbRecents;

--- a/packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx
+++ b/packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx
@@ -1,6 +1,5 @@
 /** @jest-environment jsdom */
 
-
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
@@ -18,6 +17,9 @@ import { renderHook } from "@testing-library/react";
 import { ReactNode } from "react";
 
 import { useMessagePipeline } from "@lichtblick/suite-base/components/MessagePipeline";
+import PlayerSelectionContext, {
+  PlayerSelection,
+} from "@lichtblick/suite-base/context/PlayerSelectionContext";
 import { useStateToURLSynchronization } from "@lichtblick/suite-base/hooks/useStateToURLSynchronization";
 import EventsProvider from "@lichtblick/suite-base/providers/EventsProvider";
 
@@ -25,6 +27,54 @@ jest.mock("@lichtblick/suite-base/context/CurrentLayoutContext");
 jest.mock("@lichtblick/suite-base/components/MessagePipeline");
 
 describe("useStateToURLSynchronization", () => {
+  beforeEach(() => {
+    window.history.replaceState(undefined, "", "http://localhost/");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("includes the active recent file id in the url", () => {
+    const spy = jest.spyOn(window.history, "replaceState");
+    const playerSelection: PlayerSelection = {
+      selectSource: () => {},
+      selectRecent: () => {},
+      availableSources: [],
+      recentSources: [],
+      selectedRecentId: "recent-file-id",
+    };
+
+    (useMessagePipeline as jest.Mock).mockImplementation((selector) =>
+      selector({
+        playerState: {
+          activeData: {},
+          capabilities: [],
+          urlState: {
+            sourceId: "local-file",
+            parameters: {},
+          },
+        },
+      }),
+    );
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <EventsProvider>
+        <PlayerSelectionContext.Provider value={playerSelection}>
+          {children}
+        </PlayerSelectionContext.Provider>
+      </EventsProvider>
+    );
+
+    renderHook(useStateToURLSynchronization, { wrapper });
+
+    expect(spy).toHaveBeenLastCalledWith(
+      undefined,
+      "",
+      "http://localhost/?ds=local-file&ds.recentId=recent-file-id",
+    );
+  });
+
   it("updates the url with a stable source & player state", () => {
     const spy = jest.spyOn(window.history, "replaceState");
 

--- a/packages/suite-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/suite-base/src/hooks/useStateToURLSynchronization.ts
@@ -12,6 +12,7 @@ import {
   useMessagePipeline,
 } from "@lichtblick/suite-base/components/MessagePipeline";
 import { EventsStore, useEvents } from "@lichtblick/suite-base/context/EventsContext";
+import { usePlayerSelection } from "@lichtblick/suite-base/context/PlayerSelectionContext";
 import { PlayerCapabilities } from "@lichtblick/suite-base/players/types";
 import { AppURLState, updateAppURLState } from "@lichtblick/suite-base/util/appURLState";
 
@@ -36,6 +37,7 @@ export function useStateToURLSynchronization(): void {
   const currentTime = useMessagePipeline(selectCurrentTime);
   const [debouncedCurrentTime] = useDebounce(currentTime, 500, { maxWait: 500 });
   const selectedEventId = useEvents(selectSelectedEventId);
+  const { selectedRecentId } = usePlayerSelection();
 
   // Sync current time with the url.
   useEffect(() => {
@@ -56,6 +58,7 @@ export function useStateToURLSynchronization(): void {
         {
           ...stablePlayerUrlState.parameters,
           eventId: selectedEventId,
+          recentId: selectedRecentId,
         },
         _.isString,
       ),
@@ -65,5 +68,5 @@ export function useStateToURLSynchronization(): void {
         _.isArray,
       ),
     });
-  }, [selectedEventId, stablePlayerUrlState]);
+  }, [selectedEventId, selectedRecentId, stablePlayerUrlState]);
 }


### PR DESCRIPTION
## Summary

- add `ds.recentId` to the URL for local files opened through persisted file handles
- restore the matching recent file entry after refresh once IndexedDB has loaded
- preserve all handles when reopening multiple MCAP files

## Why

Refreshing a workspace previously lost the active local file because the URL did not identify the saved recent entry that owns its file handles.

## Validation

- `yarn prettier --check packages/suite-base/src/hooks/useIndexedDbRecents.ts packages/suite-base/src/context/PlayerSelectionContext.ts packages/suite-base/src/components/PlayerManager.tsx packages/suite-base/src/hooks/useStateToURLSynchronization.ts packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx packages/suite-base/src/Workspace.tsx`
- `yarn jest packages/suite-base/src/dataSources/McapLocalDataSourceFactory.test.ts packages/suite-base/src/context/Workspace/useOpenFile.test.tsx packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx --runInBand`
