### PR TITLE
fix: skip inaccessible recent files

### DIFF
--- a/packages/suite-base/src/components/PlayerManager.tsx
+++ b/packages/suite-base/src/components/PlayerManager.tsx
@@ -248,9 +248,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
                 if (permission !== "granted") {
                   if (args.requestPermission === false) {
-                    throw new Error(
-                      `Permission required to reopen ${handle.name}. Select it from Recent data sources to grant access.`,
-                    );
+                    return;
                   }
                   if (args.requestPermission === true) {
                     throw new Error(`Permission denied: ${handle.name}`);
@@ -261,7 +259,15 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
                   }
                 }
               }
-              const filesHandled = await Promise.all(handles.map(async (f) => await f.getFile()));
+              let filesHandled: File[];
+              try {
+                filesHandled = await Promise.all(handles.map(async (f) => await f.getFile()));
+              } catch (error) {
+                if (args.requestPermission === false) {
+                  return;
+                }
+                throw error;
+              }
               if (!isMounted()) {
                 return;
               }


### PR DESCRIPTION
## Summary

- skip automatic recent-file restoration when a saved file handle is no longer accessible
- suppress permission and file-read errors during the refresh-only restore path

## Why

Refreshing a workspace cannot request file access without a user gesture. Treating an inaccessible saved handle as a normal no-op avoids showing an error when no data can be restored.

## Validation

- `yarn prettier --check packages/suite-base/src/components/PlayerManager.tsx`
- `yarn jest packages/suite-base/src/hooks/useIndexedDbRecents.test.ts packages/suite-base/src/dataSources/McapLocalDataSourceFactory.test.ts packages/suite-base/src/context/Workspace/useOpenFile.test.tsx packages/suite-base/src/hooks/useStateToURLSynchronization.test.tsx --runInBand`
