### PR TITLE
test: improve unit test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - name: build benchmark
             command: yarn run benchmark:build:prod
           - name: test
-            command: yarn run test --maxWorkers=100%
+            command: yarn run test --maxWorkers=50%
     name: ${{ matrix.config.name }} (${{ matrix.os }})
 
     steps:

--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -15,6 +15,15 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           : "${HOMEBREW_TAP_TOKEN:?Set the HOMEBREW_TAP_TOKEN repository secret}"
+          VERSION="${RELEASE_TAG#v}"
+          LINUX_ASSET="flora-${VERSION}-linux-x64.tar.gz"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
+
+          curl --fail --location --retry 3 \
+            --output "/tmp/${LINUX_ASSET}" \
+            "${RELEASE_URL}/${LINUX_ASSET}"
+          tar -tzf "/tmp/${LINUX_ASSET}" | awk -F/ '$NF == "flora" { found = 1 } END { exit !found }'
+
           curl --fail-with-body --request POST \
             --header "Accept: application/vnd.github+json" \
             --header "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \

--- a/packages/comlink-transfer-handlers/jest.config.json
+++ b/packages/comlink-transfer-handlers/jest.config.json
@@ -1,0 +1,7 @@
+{
+  "testMatch": ["<rootDir>/src/**/*.test.ts(x)?"],
+  "transform": {
+    "\\.[jt]sx?$": ["babel-jest", { "rootMode": "upward" }]
+  },
+  "haste": { "forceNodeFilesystemAPI": true }
+}

--- a/packages/comlink-transfer-handlers/src/abortSignalTransferHandler.test.ts
+++ b/packages/comlink-transfer-handlers/src/abortSignalTransferHandler.test.ts
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { abortSignalTransferHandler } from "./";
+
+describe("abortSignalTransferHandler", () => {
+  it("recognizes AbortSignal instances", () => {
+    expect(abortSignalTransferHandler.canHandle(new AbortController().signal)).toBe(true);
+    expect(abortSignalTransferHandler.canHandle({ aborted: false })).toBe(false);
+  });
+
+  it("deserializes an already-aborted signal", () => {
+    const port = {} as MessagePort;
+
+    const signal = abortSignalTransferHandler.deserialize([true, port]);
+
+    expect(signal.aborted).toBe(true);
+    expect(port.onmessage).toBeUndefined();
+  });
+
+  it("aborts a deserialized signal when its message port receives a message", () => {
+    const port = {} as MessagePort;
+    const signal = abortSignalTransferHandler.deserialize([false, port]);
+
+    expect(signal.aborted).toBe(false);
+    port.onmessage!(new MessageEvent("message"));
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("serializes a signal and forwards its abort event over the transfer port", () => {
+    const port1 = { postMessage: jest.fn() } as unknown as MessagePort;
+    const port2 = {} as MessagePort;
+    const messageChannel = jest
+      .spyOn(globalThis, "MessageChannel")
+      .mockImplementation(() => ({ port1, port2 }) as MessageChannel);
+    const controller = new AbortController();
+
+    const [serialized, transferables] = abortSignalTransferHandler.serialize(controller.signal);
+
+    expect(serialized).toEqual([false, port2]);
+    expect(transferables).toEqual([port2]);
+
+    controller.abort();
+    expect(port1.postMessage).toHaveBeenCalledWith("aborted");
+
+    messageChannel.mockRestore();
+  });
+
+  it("preserves the aborted state when serializing a signal", () => {
+    const port1 = { postMessage: jest.fn() } as unknown as MessagePort;
+    const port2 = {} as MessagePort;
+    const messageChannel = jest
+      .spyOn(globalThis, "MessageChannel")
+      .mockImplementation(() => ({ port1, port2 }) as MessageChannel);
+    const controller = new AbortController();
+    controller.abort();
+
+    const [serialized] = abortSignalTransferHandler.serialize(controller.signal);
+
+    expect(serialized).toEqual([true, port2]);
+    expect(port1.postMessage).not.toHaveBeenCalled();
+
+    messageChannel.mockRestore();
+  });
+});

--- a/packages/den/async/MutexLocked.test.ts
+++ b/packages/den/async/MutexLocked.test.ts
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MutexLocked from "./MutexLocked";
+
+describe("MutexLocked", () => {
+  it("serializes access to the wrapped value", async () => {
+    const locked = new MutexLocked({ count: 0 });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const first = locked.runExclusive(async (value) => {
+      value.count += 1;
+      await gate;
+      return value.count;
+    });
+    await Promise.resolve();
+    expect(locked.isLocked()).toBe(true);
+
+    const second = locked.runExclusive(async (value) => {
+      value.count += 1;
+      return value.count;
+    });
+    release();
+
+    await expect(first).resolves.toBe(1);
+    await expect(second).resolves.toBe(2);
+    expect(locked.isLocked()).toBe(false);
+  });
+});

--- a/packages/den/urdf/parser.test.ts
+++ b/packages/den/urdf/parser.test.ts
@@ -61,4 +61,87 @@ describe("parseUrdf", () => {
       }
     `);
   });
+
+  it("parses complete links, joints, materials, and every geometry kind", () => {
+    const robot = parseUrdf(`
+      <robot name="complete">
+        <material name="paint"><color rgba="0.1 0.2 0.3 0.4"/><texture filename="paint.png"/></material>
+        <link name="base">
+          <inertial><origin xyz="1 2 3" rpy="4 5 6"/><mass>2.5</mass><inertia ixx="1" ixy="2" ixz="3" iyy="4" iyz="5" izz="6"/></inertial>
+          <visual name="box"><geometry><box size="1 2 3"/></geometry><material name="inline"><color rgba="1 0 0 1"/></material></visual>
+          <visual name="cylinder"><geometry><cylinder length="4" radius="5"/></geometry></visual>
+          <visual name="sphere"><geometry><sphere radius="6"/></geometry></visual>
+          <collision name="mesh"><origin/><geometry><mesh filename="mesh.stl" scale="2 3 4"/></geometry></collision>
+        </link>
+        <joint name="arm" type="revolute">
+          <origin xyz="1 0 0"/><parent link="base"/><child link="tool"/><axis xyz="0 1 0"/>
+          <calibration rising="1" falling="2"/><dynamics damping="3" friction="4"/>
+          <limit lower="-1" upper="1" effort="2" velocity="3"/><mimic joint="other" multiplier="4" offset="5"/>
+          <safety_controller soft_lower_limit="-0.5" soft_upper_limit="0.5" k_position="6" k_velocity="7"/>
+        </joint>
+      </robot>
+    `);
+
+    expect(robot.materials.get("paint")).toEqual({
+      name: "paint",
+      color: { r: 0.1, g: 0.2, b: 0.3, a: 0.4 },
+      texture: "paint.png",
+    });
+    expect(robot.links.get("base")).toMatchObject({
+      inertial: {
+        origin: { xyz: { x: 1, y: 2, z: 3 }, rpy: { x: 4, y: 5, z: 6 } },
+        mass: 2.5,
+        inertia: { ixx: 1, ixy: 2, ixz: 3, iyy: 4, iyz: 5, izz: 6 },
+      },
+      visuals: [
+        { geometry: { geometryType: "box", size: { x: 1, y: 2, z: 3 } } },
+        { geometry: { geometryType: "cylinder", length: 4, radius: 5 } },
+        { geometry: { geometryType: "sphere", radius: 6 } },
+      ],
+      colliders: [
+        {
+          geometry: { geometryType: "mesh", filename: "mesh.stl", scale: { x: 2, y: 3, z: 4 } },
+        },
+      ],
+    });
+    expect(robot.joints.get("arm")).toMatchObject({
+      jointType: "revolute",
+      parent: "base",
+      child: "tool",
+      axis: { x: 0, y: 1, z: 0 },
+      calibration: { rising: 1, falling: 2 },
+      dynamics: { damping: 3, friction: 4 },
+      limit: { lower: -1, upper: 1, effort: 2, velocity: 3 },
+      mimic: { joint: "other", multiplier: 4, offset: 5 },
+      safetyController: { softLowerLimit: -0.5, softUpperLimit: 0.5, kPosition: 6, kVelocity: 7 },
+    });
+  });
+
+  it("uses defaults for omitted optional joint and pose properties", () => {
+    const robot = parseUrdf(
+      `<robot name="defaults"><link name="a"/><joint name="fixed" type="fixed"><parent link="a"/><child link="b"/></joint></robot>`,
+    );
+
+    expect(robot.joints.get("fixed")).toMatchObject({
+      origin: { xyz: { x: 0, y: 0, z: 0 }, rpy: { x: 0, y: 0, z: 0 } },
+      axis: { x: 1, y: 0, z: 0 },
+    });
+  });
+
+  it.each([
+    ['<link name="a"/>', "No robot found"],
+    ["<robot/>", "<robot> name is missing"],
+    ['<robot name="r"><joint name="j" type="invalid"/></robot>', "invalid joint type"],
+    ['<robot name="r"><link name="l"><visual/></link></robot>', "<visual> must have geometry"],
+    [
+      '<robot name="r"><link name="l"><collision/></link></robot>',
+      "<collision> must have geometry",
+    ],
+    [
+      '<robot name="r"><link name="l"><inertial><mass>1</mass></inertial></link></robot>',
+      "<inertial> must have mass and inertia",
+    ],
+  ])("rejects invalid input: %s", (xml, message) => {
+    expect(() => parseUrdf(xml)).toThrow(message);
+  });
 });

--- a/packages/den/video/AV1.test.ts
+++ b/packages/den/video/AV1.test.ts
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { AV1 } from "./AV1";
+
+describe("AV1", () => {
+  it("rejects an empty stream and OBU headers with the forbidden bit", () => {
+    expect(AV1.IsKeyframe(new Uint8Array())).toBe(false);
+    expect(AV1.IsKeyframe(new Uint8Array([0x80]))).toBe(false);
+  });
+
+  it("rejects unsupported OBUs without a size field", () => {
+    expect(() => AV1.IsKeyframe(new Uint8Array([0x28]))).toThrow("Unsupported OBU type 5");
+  });
+
+  it("reads keyframe and inter-frame headers after a sized OBU extension", () => {
+    expect(AV1.IsKeyframe(new Uint8Array([0x1a, 1, 0]))).toBe(true);
+    expect(AV1.IsKeyframe(new Uint8Array([0x1a, 1, 0x20]))).toBe(false);
+  });
+
+  it("handles the size-field offset before decoding an extended OBU", () => {
+    expect(AV1.IsKeyframe(new Uint8Array([0x1e, 0, 1, 0]))).toBe(true);
+  });
+
+  it("skips non-frame OBUs with an explicit payload size", () => {
+    expect(AV1.IsKeyframe(new Uint8Array([0x2a, 1, 0xff]))).toBe(false);
+  });
+});

--- a/packages/den/video/H264/BitstreamWriter.test.ts
+++ b/packages/den/video/H264/BitstreamWriter.test.ts
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Bitstream } from "./Bitstream";
+import { BitstreamWriter } from "./BitstreamWriter";
+
+describe("BitstreamWriter", () => {
+  it("writes aligned and unaligned fixed-width values", () => {
+    const buffer = new Uint8Array(8);
+    const writer = new BitstreamWriter(buffer);
+
+    writer.u_1(1);
+    writer.u_2(1);
+    writer.u_3(2);
+    writer.u_8(0xcc);
+    writer.finish();
+
+    expect(writer.bytesWritten()).toBe(2);
+    expect(Array.from(buffer.slice(0, 2))).toEqual([0xab, 0x30]);
+    const reader = new Bitstream(buffer.slice(0, 2));
+    expect(reader.u_1()).toBe(1);
+    expect(reader.u_2()).toBe(1);
+    expect(reader.u_3()).toBe(2);
+    expect(reader.u_8()).toBe(0xcc);
+  });
+
+  it("writes unsigned and signed exponential Golomb values", () => {
+    const buffer = new Uint8Array(16);
+    const writer = new BitstreamWriter(buffer);
+
+    writer.ue_v(0);
+    writer.ue_v(3);
+    writer.ue_v(22);
+    writer.se_v(2);
+    writer.se_v(-2);
+    writer.se_v(0);
+    writer.finish();
+
+    const reader = new Bitstream(buffer.slice(0, writer.bytesWritten()));
+    expect(reader.ue_v()).toBe(0);
+    expect(reader.ue_v()).toBe(3);
+    expect(reader.ue_v()).toBe(22);
+    expect(reader.se_v()).toBe(2);
+    expect(reader.se_v()).toBe(-2);
+    expect(reader.se_v()).toBe(0);
+  });
+
+  it("inserts an emulation prevention byte after two zero bytes", () => {
+    const buffer = new Uint8Array(4);
+    const writer = new BitstreamWriter(buffer);
+
+    writer.u_8(0);
+    writer.u_8(0);
+    writer.u(8, 1);
+    writer.finish();
+
+    expect(writer.bytesWritten()).toBe(4);
+    expect(Array.from(buffer)).toEqual([0, 0, 3, 1]);
+  });
+
+  it("rejects unsupported sizes, overflow, and writes after completion", () => {
+    const writer = new BitstreamWriter(new Uint8Array(1));
+
+    expect(() => writer.u(0, 0)).toThrow("u(0) is not supported");
+    expect(() => writer.u(33, 0)).toThrow("u(33) is not supported");
+    expect(() => writer.ue_v(0xffffffff)).toThrow("ue(v) does not support");
+    writer.finish();
+    expect(() => writer.finish()).toThrow("finish() was already called");
+    expect(() => writer.u_1(1)).toThrow("after finish");
+
+    const tooSmall = new BitstreamWriter(new Uint8Array(1));
+    tooSmall.u_8(1);
+    expect(() => tooSmall.u_8(2)).toThrow("exceed end of buffer");
+  });
+});

--- a/packages/den/video/H264/SPS.test.ts
+++ b/packages/den/video/H264/SPS.test.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { SPS } from "./SPS";
+import { BitstreamWriter } from "./BitstreamWriter";
 
 describe("SPS", () => {
   function createValidNALU() {
@@ -312,6 +313,112 @@ describe("SPS", () => {
 
       expect(() => new SPS(new Uint8Array(NALU))).toThrow(
         "SPS error: log2_max_pic_order_cnt_lsb_minus4 must be 12 or less",
+      );
+    });
+  });
+
+  describe("SPS serialization", () => {
+    it("round-trips a baseline SPS through the bitstream writer", () => {
+      const source = new SPS(new Uint8Array([0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2]));
+      const buffer = new Uint8Array(128);
+      const writer = new BitstreamWriter(buffer);
+
+      source.writeToBitstream(writer);
+      writer.finish();
+
+      const reparsed = new SPS(buffer.slice(0, writer.bytesWritten()));
+      expect(reparsed.profile_idc).toBe(66);
+      expect(reparsed.cropRect).toEqual(source.cropRect);
+      expect(reparsed.MIME()).toBe(source.MIME());
+    });
+
+    it("round-trips VUI timing and colour description fields", () => {
+      const source = new SPS(new Uint8Array(createValidNALU()));
+      const buffer = new Uint8Array(256);
+      const writer = new BitstreamWriter(buffer);
+
+      source.writeToBitstream(writer);
+      writer.finish();
+
+      const reparsed = new SPS(buffer.slice(0, writer.bytesWritten()));
+      expect(reparsed.vui_parameters_present_flag).toBe(1);
+      expect(reparsed.color_description_present_flag).toBe(1);
+      expect(reparsed.framesPerSecond).toBe(25);
+      expect(reparsed.cropRect).toEqual(source.cropRect);
+    });
+
+    it("serializes optional chroma, POC, interlacing, and VUI branches", () => {
+      const source = new SPS(new Uint8Array(createValidNALU()));
+      source.chroma_format_idc = 3;
+      source.separate_colour_plane_flag = 0;
+      source.seq_scaling_matrix_present_flag = 1;
+      source.seq_scaling_list_present_flag = Array.from({ length: 12 }, () => 0);
+      source.seq_scaling_list = [];
+      source.pic_order_cnt_type = 1;
+      source.delta_pic_order_always_zero_flag = 1;
+      source.offset_for_non_ref_pic = -2;
+      source.offset_for_top_to_bottom_field = 3;
+      source.num_ref_frames_in_pic_order_cnt_cycle = 2;
+      source.offset_for_ref_frame = [-1, 2];
+      source.frame_mbs_only_flag = 0;
+      source.mb_adaptive_frame_field_flag = 1;
+      source.vui_parameters_present_flag = 1;
+      source.aspect_ratio_info_present_flag = 1;
+      source.aspect_ratio_idc = 255;
+      source.sar_width = 4;
+      source.sar_height = 3;
+      source.overscan_info_present_flag = 1;
+      source.overscan_appropriate_flag = 1;
+      source.video_signal_type_present_flag = 1;
+      source.video_format = 5;
+      source.video_full_range_flag = 1;
+      source.color_description_present_flag = 1;
+      source.color_primaries = 1;
+      source.transfer_characteristics = 2;
+      source.matrix_coefficients = 3;
+      source.chroma_loc_info_present_flag = 1;
+      source.chroma_sample_loc_type_top_field = 1;
+      source.chroma_sample_loc_type_bottom_field = 2;
+      source.timing_info_present_flag = 1;
+      source.num_units_in_tick = 1;
+      source.time_scale = 60;
+      source.fixed_frame_rate_flag = 1;
+      source.nal_hrd_parameters_present_flag = 0;
+      source.vcl_hrd_parameters_present_flag = 0;
+      source.pic_struct_present_flag = 1;
+      source.bitstream_restriction_flag = 1;
+      source.motion_vectors_over_pic_boundaries_flag = 1;
+      source.max_bytes_per_pic_denom = 2;
+      source.max_bits_per_mb_denom = 1;
+      source.log2_max_mv_length_horizontal = 16;
+      source.log2_max_mv_length_vertical = 16;
+      source.max_num_reorder_frames = 1;
+      source.max_dec_frame_buffering = 3;
+
+      const buffer = new Uint8Array(512);
+      const writer = new BitstreamWriter(buffer);
+      source.writeToBitstream(writer);
+      writer.finish();
+
+      const reparsed = new SPS(buffer.slice(0, writer.bytesWritten()));
+      expect(reparsed.chromaArrayType).toBe(3);
+      expect(reparsed.pic_order_cnt_type).toBe(1);
+      expect(reparsed.offset_for_ref_frame).toEqual([-1, 2]);
+      expect(reparsed.interlaced).toBe(true);
+      expect(reparsed.sar_width).toBe(4);
+      expect(reparsed.sar_height).toBe(3);
+      expect(reparsed.overscan_appropriate_flag).toBe(1);
+      expect(reparsed.chroma_sample_loc_type_bottom_field).toBe(2);
+      expect(reparsed.framesPerSecond).toBe(30);
+      expect(reparsed.max_dec_frame_buffering).toBe(3);
+    });
+
+    it("rejects writing a non-SPS NAL unit", () => {
+      const source = new SPS(new Uint8Array(createValidNALU()));
+      source.nal_unit_type = 5;
+
+      expect(() => source.writeToBitstream(new BitstreamWriter(new Uint8Array(128)))).toThrow(
+        "Expected SPS NALU, got 5",
       );
     });
   });

--- a/packages/den/video/H265.test.ts
+++ b/packages/den/video/H265.test.ts
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { H265 } from "./H265";
+
+describe("H265", () => {
+  it("recognizes Annex B start codes", () => {
+    expect(H265.IsAnnexB(new Uint8Array([0, 0, 1, 0x26]))).toBe(true);
+    expect(H265.IsAnnexB(new Uint8Array([1, 2, 3, 4]))).toBe(false);
+  });
+
+  it("finds IRAP NAL units across an Annex B stream", () => {
+    expect(H265.IsKeyframe(new Uint8Array([0, 0, 1, 0x02, 0, 0, 1, 0x26]))).toBe(true);
+    expect(H265.IsKeyframe(new Uint8Array([0, 0, 1, 0x02, 0, 0, 1, 0x1e]))).toBe(false);
+    expect(H265.IsKeyframe(new Uint8Array([1, 2, 3, 4]))).toBe(false);
+  });
+});

--- a/packages/den/video/VP9.test.ts
+++ b/packages/den/video/VP9.test.ts
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { VP9 } from "./VP9";
+
+describe("VP9", () => {
+  it("rejects empty frames and invalid frame markers", () => {
+    expect(VP9.IsKeyframe(new Uint8Array())).toBe(false);
+    expect(() => VP9.IsKeyframe(new Uint8Array([0]))).toThrow("expected frame_marker 2");
+  });
+
+  it("identifies visible keyframes for regular and profile-three headers", () => {
+    expect(VP9.IsKeyframe(new Uint8Array([0x82]))).toBe(true);
+    expect(VP9.IsKeyframe(new Uint8Array([0xb1]))).toBe(true);
+    expect(VP9.IsKeyframe(new Uint8Array([0x86]))).toBe(false);
+    expect(VP9.IsKeyframe(new Uint8Array([0xb3]))).toBe(false);
+    expect(VP9.IsKeyframe(new Uint8Array([0x8a]))).toBe(false);
+  });
+});

--- a/packages/den/video/index.test.ts
+++ b/packages/den/video/index.test.ts
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { getFrameInfo, isVideoFrame } from "./index";
+
+describe("video helpers", () => {
+  it("dispatches supported compressed video formats", () => {
+    expect(
+      getFrameInfo({ format: "h264", data: new Uint8Array([0, 0, 1, 0x65]) } as never),
+    ).toEqual({
+      isKeyFrame: true,
+      mayNeedRewrite: true,
+    });
+    expect(
+      getFrameInfo({ format: "h265", data: new Uint8Array([0, 0, 1, 0x26]) } as never),
+    ).toEqual({
+      isKeyFrame: true,
+      mayNeedRewrite: false,
+    });
+    expect(getFrameInfo({ format: "vp9", data: new Uint8Array([0x82]) } as never)).toEqual({
+      isKeyFrame: true,
+      mayNeedRewrite: false,
+    });
+    expect(getFrameInfo({ format: "av1", data: new Uint8Array([0x1a, 1, 0]) } as never)).toEqual({
+      isKeyFrame: true,
+      mayNeedRewrite: false,
+    });
+    expect(getFrameInfo({ format: "other", data: new Uint8Array() } as never)).toEqual({
+      isKeyFrame: false,
+      mayNeedRewrite: false,
+    });
+  });
+
+  it("recognizes VideoFrame only when the constructor exists", () => {
+    const original = globalThis.VideoFrame;
+    class TestVideoFrame {}
+    Object.assign(globalThis, { VideoFrame: TestVideoFrame });
+
+    expect(isVideoFrame(new TestVideoFrame())).toBe(true);
+    expect(isVideoFrame({})).toBe(false);
+
+    Object.assign(globalThis, { VideoFrame: original });
+  });
+});

--- a/packages/hooks/jest.config.json
+++ b/packages/hooks/jest.config.json
@@ -1,6 +1,7 @@
 {
   "testMatch": ["<rootDir>/src/**/*.test.ts(x)?"],
   "setupFiles": ["<rootDir>/test/setup.ts"],
+  "testEnvironment": "jsdom",
   "transform": {
     "\\.[jt]sx?$": ["babel-jest", { "rootMode": "upward" }]
   },

--- a/packages/hooks/src/selectWithUnstableIdentityWarning.test.ts
+++ b/packages/hooks/src/selectWithUnstableIdentityWarning.test.ts
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { selectWithUnstableIdentityWarning } from "./selectWithUnstableIdentityWarning";
+
+describe("selectWithUnstableIdentityWarning", () => {
+  it("returns the selector result", () => {
+    const selector = jest.fn((value: { count: number }) => value.count * 2);
+
+    expect(selectWithUnstableIdentityWarning({ count: 3 }, selector)).toBe(6);
+    expect(selector).toHaveBeenCalledWith({ count: 3 });
+  });
+});

--- a/packages/hooks/src/useGuaranteedContext.test.tsx
+++ b/packages/hooks/src/useGuaranteedContext.test.tsx
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { renderHook } from "@testing-library/react";
+import { createContext, type ReactNode } from "react";
+
+import useGuaranteedContext from "./useGuaranteedContext";
+
+describe("useGuaranteedContext", () => {
+  const Context = createContext<string | undefined>(undefined);
+
+  it("returns the supplied context value", () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Context.Provider value="value">{children}</Context.Provider>
+    );
+
+    expect(renderHook(() => useGuaranteedContext(Context), { wrapper }).result.current).toBe("value");
+  });
+
+  it("throws a named error when the provider is absent", () => {
+    expect(() => renderHook(() => useGuaranteedContext(Context, "TestContext"))).toThrow(
+      "useGuaranteedContext got null for contextType: 'TestContext'",
+    );
+  });
+
+  it("throws a generic error when the provider is absent without a debug name", () => {
+    expect(() => renderHook(() => useGuaranteedContext(Context))).toThrow(
+      "useGuaranteedContext got null for contextType",
+    );
+  });
+});

--- a/packages/hooks/src/useMemoryInfo.test.tsx
+++ b/packages/hooks/src/useMemoryInfo.test.tsx
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, renderHook } from "@testing-library/react";
+
+import { useMemoryInfo } from "./useMemoryInfo";
+
+describe("useMemoryInfo", () => {
+  afterEach(() => jest.useRealTimers());
+
+  it("returns browser memory information and refreshes it at the requested interval", () => {
+    jest.useFakeTimers();
+    const { result, unmount } = renderHook(() => useMemoryInfo({ refreshIntervalMs: 100 }));
+
+    expect(result.current).toEqual({ jsHeapSizeLimit: 100, totalJSHeapSize: 50, usedJSHeapSize: 25 });
+
+    act(() => jest.advanceTimersByTime(100));
+    expect(result.current?.usedJSHeapSize).toBe(25);
+
+    unmount();
+  });
+});

--- a/packages/hooks/src/useMustNotChange.test.ts
+++ b/packages/hooks/src/useMustNotChange.test.ts
@@ -8,9 +8,13 @@ import { renderHook } from "@testing-library/react";
 
 import Logger from "@lichtblick/log";
 
-import { useMustNotChangeImpl } from "./useMustNotChange";
+import useMustNotChange, { useMustNotChangeImpl } from "./useMustNotChange";
 
 describe("useMustNotChange", () => {
+  it("is a no-op outside development mode", () => {
+    expect(() => renderHook(() => useMustNotChange("value"))).not.toThrow();
+  });
+
   it("should log an error when value changes", () => {
     const errorMock = jest.fn();
     Logger.channels().forEach((channel) => {

--- a/packages/hooks/src/useSessionStorageValue.test.tsx
+++ b/packages/hooks/src/useSessionStorageValue.test.tsx
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, renderHook } from "@testing-library/react";
+
+import { useSessionStorageValue } from "./useSessionStorageValue";
+
+describe("useSessionStorageValue", () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it("reads, updates, removes, and follows storage events for a key", () => {
+    sessionStorage.setItem("key", "initial");
+    const { result } = renderHook(() => useSessionStorageValue("key"));
+
+    expect(result.current[0]).toBe("initial");
+    act(() => result.current[1]("updated"));
+    expect(sessionStorage.getItem("key")).toBe("updated");
+    expect(result.current[0]).toBe("updated");
+
+    act(() => result.current[1](undefined));
+    expect(sessionStorage.getItem("key")).toBeNull();
+    expect(result.current[0]).toBeUndefined();
+
+    act(() => window.dispatchEvent(new StorageEvent("storage", { key: "key", newValue: "remote" })));
+    expect(result.current[0]).toBe("remote");
+
+    act(() => window.dispatchEvent(new StorageEvent("storage", { key: "other", newValue: "ignored" })));
+    expect(result.current[0]).toBe("remote");
+  });
+});

--- a/packages/hooks/src/useWarnImmediateReRender.test.tsx
+++ b/packages/hooks/src/useWarnImmediateReRender.test.tsx
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { renderHook } from "@testing-library/react";
+
+import useWarnImmediateReRender from "./useWarnImmediateReRender";
+
+describe("useWarnImmediateReRender", () => {
+  it("is safe to call outside development mode", () => {
+    expect(() => renderHook(() => useWarnImmediateReRender())).not.toThrow();
+  });
+});

--- a/packages/hooks/test/setup.ts
+++ b/packages/hooks/test/setup.ts
@@ -4,3 +4,8 @@
 
 // React available everywhere (matches webpack config)
 global.React = require("react");
+
+Object.defineProperty(window.performance, "memory", {
+  configurable: true,
+  value: { jsHeapSizeLimit: 100, totalJSHeapSize: 50, usedJSHeapSize: 25 },
+});

--- a/packages/log/jest.config.json
+++ b/packages/log/jest.config.json
@@ -1,0 +1,7 @@
+{
+  "testMatch": ["<rootDir>/src/**/*.test.ts(x)?"],
+  "transform": {
+    "\\.[jt]sx?$": ["babel-jest", { "rootMode": "upward" }]
+  },
+  "haste": { "forceNodeFilesystemAPI": true }
+}

--- a/packages/log/src/index.test.ts
+++ b/packages/log/src/index.test.ts
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import DefaultLogger, { Logger, type LogLevel, toLogLevel } from "./index";
+
+describe("Logger", () => {
+  const prefix = "log-test";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ["debug", "debug"],
+    ["info", "info"],
+    ["warn", "warn"],
+    ["error", "error"],
+    ["unexpected", "warn"],
+  ])("normalizes %s to %s", (input, expected) => {
+    expect(toLogLevel(input)).toBe(expected);
+  });
+
+  it("returns cached child loggers and normalizes webpack paths", () => {
+    const parent = DefaultLogger.getLogger(`${prefix}.parent`);
+    const child = parent.getLogger("/tmp/app.asar/renderer");
+
+    expect(child.name()).toBe(`${prefix}.parent.renderer`);
+    expect(parent.getLogger("/tmp/app.asar/renderer")).toBe(child);
+    expect(parent.getLogger("../../worker").name()).toBe(`${prefix}.parent.worker`);
+    expect(DefaultLogger.channels()).toEqual(expect.arrayContaining([DefaultLogger, parent, child]));
+  });
+
+  it("does not enable an unrecognized log level", () => {
+    expect(DefaultLogger.isLevelOn("trace" as LogLevel)).toBe(false);
+  });
+
+  it("provides no-op prototype methods before a log level binds console methods", () => {
+    expect(() => {
+      Logger.prototype.debug("debug");
+      Logger.prototype.info("info");
+      Logger.prototype.warn("warn");
+      Logger.prototype.error("error");
+    }).not.toThrow();
+  });
+
+  it.each([
+    ["debug", ["debug", "info", "warn", "error"]],
+    ["info", ["info", "warn", "error"]],
+    ["warn", ["warn", "error"]],
+    ["error", ["error"]],
+  ] as const)("enables only %s and higher severity logs", (level, enabled) => {
+    const logger = DefaultLogger.getLogger(`${prefix}.${level}`);
+    const debug = jest.spyOn(console, "debug").mockImplementation(() => {});
+    const info = jest.spyOn(console, "info").mockImplementation(() => {});
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const error = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    logger.setLevel(level);
+    logger.debug("debug");
+    logger.info("info");
+    logger.warn("warn");
+    logger.error("error");
+
+    expect(logger.getLevel()).toBe(level);
+    for (const candidate of ["debug", "info", "warn", "error"] as const) {
+      expect(logger.isLevelOn(candidate)).toBe(enabled.includes(candidate));
+    }
+    expect(debug).toHaveBeenCalledTimes(enabled.includes("debug") ? 1 : 0);
+    expect(info).toHaveBeenCalledTimes(enabled.includes("info") ? 1 : 0);
+    expect(warn).toHaveBeenCalledTimes(enabled.includes("warn") ? 1 : 0);
+    expect(error).toHaveBeenCalledTimes(enabled.includes("error") ? 1 : 0);
+  });
+});

--- a/packages/mcap-support/src/fixtures/byte-vector.test.ts
+++ b/packages/mcap-support/src/fixtures/byte-vector.test.ts
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Builder, ByteBuffer } from "flatbuffers";
+
+import { ByteVector } from "./byte-vector";
+
+function buildVector(data?: number[], sizePrefixed = false): Uint8Array {
+  const builder = new Builder();
+  const dataOffset = data == undefined ? undefined : ByteVector.createDataVector(builder, data);
+  ByteVector.startByteVector(builder);
+  if (dataOffset != undefined) {
+    ByteVector.addData(builder, dataOffset);
+  }
+  const offset = ByteVector.endByteVector(builder);
+  if (sizePrefixed) {
+    ByteVector.finishSizePrefixedByteVectorBuffer(builder, offset);
+  } else {
+    ByteVector.finishByteVectorBuffer(builder, offset);
+  }
+  return builder.asUint8Array();
+}
+
+describe("ByteVector", () => {
+  it("reads a vector created with the generated helpers", () => {
+    const bytes = buildVector([1, 2, 3]);
+    const vector = ByteVector.getRootAsByteVector(new ByteBuffer(bytes));
+
+    expect(vector.dataLength()).toBe(3);
+    expect(vector.data(1)).toBe(2);
+    expect(vector.dataArray()).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("supports size-prefixed buffers and caller-provided instances", () => {
+    const bytes = buildVector([4], true);
+    const reusable = new ByteVector();
+    const vector = ByteVector.getSizePrefixedRootAsByteVector(new ByteBuffer(bytes), reusable);
+
+    expect(vector).toBe(reusable);
+    expect(vector.data(0)).toBe(4);
+  });
+
+  it("returns generated defaults when the vector field is absent", () => {
+    const vector = ByteVector.getRootAsByteVector(new ByteBuffer(buildVector()));
+
+    expect(vector.data(0)).toBe(0);
+    expect(vector.dataLength()).toBe(0);
+    expect(vector.dataArray()).toBeNull();
+  });
+
+  it("exposes the manual vector-builder helpers", () => {
+    const builder = new Builder();
+    ByteVector.startDataVector(builder, 0);
+    const data = builder.endVector();
+    const vector = ByteVector.createByteVector(builder, data);
+    ByteVector.finishByteVectorBuffer(builder, vector);
+
+    expect(ByteVector.getRootAsByteVector(new ByteBuffer(builder.asUint8Array())).dataLength()).toBe(0);
+  });
+});

--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -8,6 +8,50 @@ import { FileDescriptorSet, IFileDescriptorSet } from "protobufjs/ext/descriptor
 import { parseChannel } from "./parseChannel";
 
 describe("parseChannel", () => {
+  const bytes = (value: string) => new TextEncoder().encode(value);
+
+  it.each([
+    ["json", { name: "X", encoding: "protobuf", data: bytes("") }],
+    ["flatbuffer", { name: "X", encoding: "protobuf", data: bytes("") }],
+    ["protobuf", { name: "X", encoding: "flatbuffer", data: bytes("") }],
+    ["ros1", { name: "X", encoding: "ros2msg", data: bytes("string value") }],
+    ["cdr", { name: "X", encoding: "protobuf", data: bytes("") }],
+  ])("rejects an incompatible schema encoding for %s", (messageEncoding, schema) => {
+    expect(() => parseChannel({ messageEncoding, schema })).toThrow("not supported");
+  });
+
+  it("rejects unsupported message encodings", () => {
+    expect(() => parseChannel({ messageEncoding: "custom", schema: undefined })).toThrow(
+      "Unsupported encoding custom",
+    );
+  });
+
+  it("rejects non-object JSON schemas", () => {
+    expect(() =>
+      parseChannel({
+        messageEncoding: "json",
+        schema: { name: "X", encoding: "jsonschema", data: bytes("true") },
+      }),
+    ).toThrow("Invalid schema, expected JSON object");
+  });
+
+  it("allows configured and well-known empty ROS schemas", () => {
+    const emptyRosSchema = { name: "custom_msgs/Empty", encoding: "ros1msg", data: bytes("") };
+
+    expect(() => parseChannel({ messageEncoding: "ros1", schema: emptyRosSchema })).toThrow(
+      "Schema for custom_msgs/Empty is empty",
+    );
+    expect(() =>
+      parseChannel({ messageEncoding: "ros1", schema: emptyRosSchema }, { allowEmptySchema: true }),
+    ).not.toThrow();
+    expect(() =>
+      parseChannel({
+        messageEncoding: "ros2",
+        schema: { name: "std_msgs/msg/Empty", encoding: "ros2msg", data: bytes("") },
+      }),
+    ).toThrow("Unsupported encoding ros2");
+  });
+
   it("works with json/jsonschema", () => {
     const channel = parseChannel({
       messageEncoding: "json",

--- a/packages/mcap-support/src/parseFlatbufferSchema.test.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.test.ts
@@ -361,6 +361,13 @@ describe("parseFlatbufferSchema", () => {
       index: 123,
     });
   });
+  it("rejects a type that is absent from the schema", () => {
+    const reflectionSchema = fs.readFileSync(`${__dirname}/fixtures/reflection.bfbs`);
+
+    expect(() => parseFlatbufferSchema("reflection.Unknown", reflectionSchema)).toThrow(
+      'Type "reflection.Unknown" is not available in the schema',
+    );
+  });
   it("converts uint8 vectors to uint8arrays", () => {
     const builder = new Builder();
 

--- a/packages/suite-base/src/IdbLayoutStorage.test.ts
+++ b/packages/suite-base/src/IdbLayoutStorage.test.ts
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { IdbLayoutStorage } from "./IdbLayoutStorage";
+
+const makeLayout = (id: string) =>
+  ({
+    id,
+    name: `Layout ${id}`,
+    permission: "CREATOR_WRITE",
+    baseline: { data: { configById: {}, layout: "" }, savedAt: undefined },
+    working: undefined,
+    syncInfo: undefined,
+  }) as never;
+
+describe("IdbLayoutStorage", () => {
+  it("stores, lists, reads, deletes, and migrates namespaced layouts", async () => {
+    const storage = new IdbLayoutStorage();
+    const first = makeLayout(`first-${Date.now()}`);
+    const second = makeLayout(`second-${Date.now()}`);
+    const sourceNamespace = `source-${Date.now()}`;
+
+    await expect(storage.put(sourceNamespace, first)).resolves.toEqual(first);
+    await storage.put(sourceNamespace, second);
+    await expect(storage.list(sourceNamespace)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: first.id }),
+        expect.objectContaining({ id: second.id }),
+      ]),
+    );
+    await expect(storage.get(sourceNamespace, first.id)).resolves.toEqual(
+      expect.objectContaining({ id: first.id }),
+    );
+    await expect(storage.get(sourceNamespace, "missing")).resolves.toBeUndefined();
+    await storage.put(sourceNamespace, { id: "invalid-layout" } as never);
+    await expect(storage.list(sourceNamespace)).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: first.id })]),
+    );
+    (console.error as jest.Mock).mockClear();
+
+    await storage.delete(sourceNamespace, first.id);
+    await expect(storage.get(sourceNamespace, first.id)).resolves.toBeUndefined();
+    await storage.migrateUnnamespacedLayouts(sourceNamespace);
+  });
+
+  it("migrates valid legacy localStorage layouts", async () => {
+    const storage = new IdbLayoutStorage();
+    const namespace = `legacy-${Date.now()}`;
+    const layout = makeLayout(`layout-${Date.now()}`);
+    const validKey = `studio.layouts.${namespace}.${layout.id}`;
+    localStorage.setItem(validKey, JSON.stringify(layout));
+
+    await storage.migrateUnnamespacedLayouts(namespace);
+
+    await expect(storage.get(namespace, layout.id)).resolves.toEqual(
+      expect.objectContaining({ id: layout.id }),
+    );
+    expect(localStorage.getItem(validKey)).toBeNull();
+  });
+
+  it("retains malformed legacy localStorage entries without stopping migration", async () => {
+    const storage = new IdbLayoutStorage();
+    const namespace = `invalid-${Date.now()}`;
+    const layout = makeLayout(`layout-${Date.now()}`);
+    const invalidJsonKey = `studio.layouts.${namespace}.invalid-json`;
+    const mismatchedKey = `studio.layouts.${namespace}.wrong-id`;
+    localStorage.setItem(invalidJsonKey, "not json");
+    localStorage.setItem(mismatchedKey, JSON.stringify(layout));
+
+    await storage.migrateUnnamespacedLayouts(namespace);
+
+    expect(localStorage.getItem(invalidJsonKey)).toBe("not json");
+    expect(localStorage.getItem(mismatchedKey)).not.toBeNull();
+    (console.error as jest.Mock).mockClear();
+    localStorage.removeItem(invalidJsonKey);
+    localStorage.removeItem(mismatchedKey);
+  });
+});

--- a/packages/suite-base/src/components/Chart/datasets.test.ts
+++ b/packages/suite-base/src/components/Chart/datasets.test.ts
@@ -2,45 +2,45 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { findIndices } from "./datasets";
+import { findIndices, iterateObjects, iterateTyped } from "./datasets";
 
-describe("findIndices", () => {
-  it("ignores empty slices", () => {
+describe("chart datasets", () => {
+  it("iterates object points while preserving source indexes", () => {
     expect(
-      findIndices(
-        [
-          {
-            x: new Float32Array(),
-            y: new Float32Array(),
-            value: [],
-          },
-          {
-            x: new Float32Array(1),
-            y: new Float32Array(1),
-            value: ["foo"],
-          },
-        ],
-        0,
-      ),
-    ).toEqual([1, 0]);
+      Array.from(iterateObjects([{ x: 1, y: 2, label: "one" }, null, { x: 3, y: 4 }] as never)),
+    ).toEqual([
+      { index: 0, x: 1, y: 2, label: "one" },
+      { index: 2, x: 3, y: 4, label: undefined },
+    ]);
   });
-  it("calculates index correctly", () => {
-    expect(
-      findIndices(
-        [
-          {
-            x: new Float32Array(3),
-            y: new Float32Array(3),
-            value: [1, 2, 3],
-          },
-          {
-            x: new Float32Array(1),
-            y: new Float32Array(1),
-            value: [4],
-          },
-        ],
-        3,
-      ),
-    ).toEqual([1, 0]);
+
+  it("iterates typed slices and carries all point fields", () => {
+    const values = Array.from(
+      iterateTyped([
+        { x: new Float32Array([1, 2]), y: new Float32Array([3, 4]), label: ["a", "b"] },
+        {} as never,
+        { x: new Float32Array([5]), y: new Float32Array([6]), label: ["c"] },
+      ]),
+      (point) => ({ ...point }),
+    );
+
+    expect(values).toEqual([
+      { index: 0, label: "a", x: 1, y: 3 },
+      { index: 1, label: "b", x: 2, y: 4 },
+      { index: 2, label: "c", x: 5, y: 6 },
+    ]);
+  });
+
+  it("locates global indexes across typed slices", () => {
+    const data = [
+      { x: new Float32Array([1, 2]), y: new Float32Array([3, 4]), value: [] },
+      undefined,
+      { x: new Float32Array([5]), y: new Float32Array([6]), value: [] },
+    ] as never;
+
+    expect(findIndices(data, 0)).toEqual([0, 0]);
+    expect(findIndices(data, 2)).toEqual([2, 0]);
+    expect(findIndices(data, 3)).toEqual([2, 1]);
+    expect(findIndices(data, 4)).toBeUndefined();
   });
 });

--- a/packages/suite-base/src/components/Chart/worker/proxy.test.ts
+++ b/packages/suite-base/src/components/Chart/worker/proxy.test.ts
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { proxyTyped } from "./proxy";
+
+describe("proxyTyped", () => {
+  it("presents typed data slices as a read-only Chart.js point array", () => {
+    const result = proxyTyped({
+      datasets: [
+        {
+          label: "series",
+          data: [
+            { x: new Float32Array([1, 2]), y: new Float32Array([3, 4]), value: ["a", "b"] },
+            { x: new Float32Array([5]), y: new Float32Array([6]), value: ["c"] },
+          ],
+        },
+      ],
+    } as never);
+    const data = result.datasets[0]!.data as unknown as Record<string, unknown>;
+
+    expect(data.length).toBe(3);
+    expect(data[0]).toEqual({ x: 1, y: 3, value: "a" });
+    expect(data[1]).toEqual({ x: 2, y: 4, value: "b" });
+    expect(data[2]).toEqual({ x: 5, y: 6, value: "c" });
+    expect(data[3]).toBeUndefined();
+    expect(data[-1]).toBeUndefined();
+    expect(data._chartjs).toBeUndefined();
+    expect(Reflect.get(data, Symbol.iterator)).toBeDefined();
+    expect(Object.isExtensible(data)).toBe(false);
+  });
+
+  it("returns undefined if a typed slice is removed after proxy creation", () => {
+    const source = {
+      datasets: [{ data: [{ x: new Float32Array([1]), y: new Float32Array([2]), value: ["a"] }] }],
+    };
+    const result = proxyTyped(source as never);
+    source.datasets[0]!.data.length = 0;
+
+    expect((result.datasets[0]!.data as unknown as Record<string, unknown>)[0]).toBeUndefined();
+  });
+
+  it("handles datasets without data points", () => {
+    const result = proxyTyped({ datasets: [{ data: [] }] } as never);
+
+    expect(result.datasets[0]!.data).toHaveLength(0);
+  });
+});

--- a/packages/suite-base/src/components/CopyButton.test.tsx
+++ b/packages/suite-base/src/components/CopyButton.test.tsx
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import clipboard from "@lichtblick/suite-base/util/clipboard";
+
+import CopyButton from "./CopyButton";
+
+jest.mock("@lichtblick/suite-base/util/clipboard", () => ({ copy: jest.fn() }));
+
+describe("CopyButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("copies generated text and displays success feedback", async () => {
+    (clipboard.copy as jest.Mock).mockResolvedValue(undefined);
+    render(<CopyButton getText={() => "copied text"} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(clipboard.copy).toHaveBeenCalledWith("copied text");
+    await waitFor(() =>
+      expect(screen.getByRole("button").classList.contains("MuiIconButton-colorSuccess")).toBe(
+        true,
+      ),
+    );
+  });
+
+  it("renders a text button and handles failed clipboard writes", async () => {
+    (clipboard.copy as jest.Mock).mockRejectedValue(new Error("denied"));
+    render(<CopyButton getText={() => "text"}>Copy value</CopyButton>);
+    fireEvent.click(screen.getByRole("button", { name: "Copy value" }));
+    await waitFor(() => expect(console.warn).toHaveBeenCalled());
+    expect(clipboard.copy).toHaveBeenCalledWith("text");
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("supports the small and large icon variants", async () => {
+    (clipboard.copy as jest.Mock).mockResolvedValue(undefined);
+    const { rerender } = render(<CopyButton getText={() => "small"} iconSize="small" />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(screen.getByRole("button").getAttribute("aria-label")).toBe("Copied"),
+    );
+    rerender(<CopyButton getText={() => "large"} iconSize="large" />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(clipboard.copy).toHaveBeenCalledWith("large"));
+  });
+});

--- a/packages/suite-base/src/components/LayoutBrowser/reducer.test.tsx
+++ b/packages/suite-base/src/components/LayoutBrowser/reducer.test.tsx
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { act, renderHook } from "@testing-library/react";
+
+import { useLayoutBrowserReducer } from "./reducer";
+
+const props = { busy: false, error: undefined, online: true, lastSelectedId: undefined };
+
+describe("useLayoutBrowserReducer", () => {
+  it("selects ids with ordinary and modifier clicks", () => {
+    const { result } = renderHook(() => useLayoutBrowserReducer(props));
+    const dispatch = result.current[1];
+    act(() => dispatch({ type: "select-id", id: "one" }));
+    act(() => dispatch({ type: "select-id", id: "two", modKey: true }));
+    expect(result.current[0].selectedIds).toEqual(["one", "two"]);
+    act(() => dispatch({ type: "select-id", id: "one", modKey: true }));
+    expect(result.current[0].selectedIds).toEqual(["two"]);
+  });
+
+  it("selects a range and updates state flags", () => {
+    const { result } = renderHook(() =>
+      useLayoutBrowserReducer({ ...props, lastSelectedId: "two" }),
+    );
+    const dispatch = result.current[1];
+    const layouts = {
+      personal: [{ id: "one" }, { id: "two" }, { id: "three" }],
+      shared: [],
+    } as never;
+    act(() => dispatch({ type: "select-id", id: "three", shiftKey: true, layouts }));
+    act(() => dispatch({ type: "set-busy", value: true }));
+    act(() => dispatch({ type: "set-online", value: false }));
+    act(() => dispatch({ type: "set-error", value: new Error("failed") }));
+    expect(result.current[0]).toMatchObject({
+      selectedIds: ["two", "three"],
+      busy: true,
+      online: false,
+    });
+    expect(result.current[0].error).toMatchObject({ message: "failed" });
+  });
+
+  it("queues, advances, and clears multi-actions", () => {
+    const { result } = renderHook(() => useLayoutBrowserReducer(props));
+    const dispatch = result.current[1];
+    act(() => dispatch({ type: "select-id", id: "one" }));
+    act(() => dispatch({ type: "select-id", id: "two", modKey: true }));
+    act(() => dispatch({ type: "queue-multi-action", action: "delete" }));
+    expect(result.current[0].multiAction).toEqual({ action: "delete", ids: ["one", "two"] });
+    act(() => dispatch({ type: "shift-multi-action" }));
+    expect(result.current[0].selectedIds).toEqual(["two"]);
+    act(() => dispatch({ type: "shift-multi-action" }));
+    expect(result.current[0].multiAction).toBeUndefined();
+    act(() => dispatch({ type: "clear-multi-action" }));
+    expect(result.current[0].multiAction).toBeUndefined();
+  });
+});

--- a/packages/suite-base/src/dataSources/Ros2LocalBagDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/Ros2LocalBagDataSourceFactory.test.ts
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import {
+  IterablePlayer,
+  WorkerIterableSource,
+} from "@lichtblick/suite-base/players/IterablePlayer";
+
+import Ros2LocalBagDataSourceFactory from "./Ros2LocalBagDataSourceFactory";
+
+jest.mock("@lichtblick/suite-base/players/IterablePlayer", () => ({
+  IterablePlayer: jest.fn(),
+  WorkerIterableSource: jest.fn(),
+}));
+
+describe("Ros2LocalBagDataSourceFactory", () => {
+  it("builds an iterable source from one or many ROS 2 bag files", () => {
+    const factory = new Ros2LocalBagDataSourceFactory();
+    expect(factory.initialize({} as never)).toBeUndefined();
+    const first = new File(["a"], "first.db3");
+    const second = new File(["b"], "second.db3");
+    const metricsCollector = {} as never;
+    factory.initialize({ files: [first, second], metricsCollector } as never);
+    expect(WorkerIterableSource).toHaveBeenCalledWith(
+      expect.objectContaining({ initArgs: { files: [first, second] } }),
+    );
+    expect(IterablePlayer).toHaveBeenCalledWith({
+      metricsCollector,
+      source: (WorkerIterableSource as jest.Mock).mock.instances[0],
+      name: "first.db3, second.db3",
+      sourceId: "ros2-local-bagfile",
+    });
+    const initWorker = (WorkerIterableSource as jest.Mock).mock.calls[0]![0]
+      .initWorker as () => unknown;
+    const WorkerMock = jest.fn();
+    (global as unknown as { Worker: typeof WorkerMock }).Worker = WorkerMock;
+    initWorker();
+    expect(WorkerMock).toHaveBeenCalledTimes(1);
+
+    const single = new File(["single"], "single.db3");
+    factory.initialize({ file: single, metricsCollector } as never);
+    expect(IterablePlayer).toHaveBeenLastCalledWith(
+      expect.objectContaining({ name: "single.db3", sourceId: "ros2-local-bagfile" }),
+    );
+  });
+});

--- a/packages/suite-base/src/dataSources/RosbridgeDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/RosbridgeDataSourceFactory.test.ts
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import RosbridgePlayer from "@lichtblick/suite-base/players/RosbridgePlayer";
+
+import RosbridgeDataSourceFactory from "./RosbridgeDataSourceFactory";
+
+jest.mock("@lichtblick/suite-base/players/RosbridgePlayer", () => jest.fn());
+
+describe("RosbridgeDataSourceFactory", () => {
+  it("validates WebSocket URLs and constructs a player only when configured", () => {
+    const factory = new RosbridgeDataSourceFactory();
+    const validate = factory.formConfig.fields[0]!.validate!;
+    expect(validate("ws://localhost:9090")).toBeUndefined();
+    expect(validate("wss://example.com")).toBeUndefined();
+    expect(validate("http://example.com")?.message).toContain("Invalid protocol");
+    expect(validate("not a URL")?.message).toBe("Enter a valid url");
+    expect(factory.initialize({} as never)).toBeUndefined();
+
+    const metricsCollector = {} as never;
+    factory.initialize({ params: { url: "ws://robot:9090" }, metricsCollector } as never);
+    expect(RosbridgePlayer).toHaveBeenCalledWith({
+      url: "ws://robot:9090",
+      metricsCollector,
+      sourceId: "rosbridge-websocket",
+    });
+  });
+});

--- a/packages/suite-base/src/dataSources/SampleNuscenesDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/SampleNuscenesDataSourceFactory.test.ts
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import {
+  IterablePlayer,
+  WorkerIterableSource,
+} from "@lichtblick/suite-base/players/IterablePlayer";
+
+import SampleNuscenesDataSourceFactory from "./SampleNuscenesDataSourceFactory";
+
+jest.mock("@lichtblick/suite-base/players/IterablePlayer", () => ({
+  IterablePlayer: jest.fn(),
+  WorkerIterableSource: jest.fn(),
+}));
+
+describe("SampleNuscenesDataSourceFactory", () => {
+  it("creates the hidden sample source and corresponding player", () => {
+    const factory = new SampleNuscenesDataSourceFactory();
+    const metricsCollector = {} as never;
+    expect(factory).toMatchObject({ id: "sample-nuscenes", type: "sample", hidden: true });
+    factory.initialize({ metricsCollector } as never);
+    expect(WorkerIterableSource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initArgs: expect.objectContaining({ url: expect.stringContaining("NuScenes") }),
+      }),
+    );
+    expect(IterablePlayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: (WorkerIterableSource as jest.Mock).mock.instances[0],
+        isSampleDataSource: true,
+        metricsCollector,
+        urlParams: {},
+        sourceId: "sample-nuscenes",
+      }),
+    );
+    const initWorker = (WorkerIterableSource as jest.Mock).mock.calls[0]![0]
+      .initWorker as () => unknown;
+    const WorkerMock = jest.fn();
+    (global as unknown as { Worker: typeof WorkerMock }).Worker = WorkerMock;
+    initWorker();
+    expect(WorkerMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/suite-base/src/dataSources/UlogLocalDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/UlogLocalDataSourceFactory.test.ts
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import {
+  IterablePlayer,
+  WorkerIterableSource,
+} from "@lichtblick/suite-base/players/IterablePlayer";
+
+import UlogLocalDataSourceFactory from "./UlogLocalDataSourceFactory";
+
+jest.mock("@lichtblick/suite-base/players/IterablePlayer", () => ({
+  IterablePlayer: jest.fn(),
+  WorkerIterableSource: jest.fn(),
+}));
+
+describe("UlogLocalDataSourceFactory", () => {
+  it("requires a file and creates an iterable player for supported ULog input", () => {
+    const factory = new UlogLocalDataSourceFactory();
+    expect(factory.supportedFileTypes).toEqual([".ulg", ".ulog"]);
+    expect(factory.initialize({} as never)).toBeUndefined();
+
+    const file = new File(["log"], "flight.ulg");
+    const metricsCollector = {} as never;
+    factory.initialize({ file, metricsCollector } as never);
+    expect(WorkerIterableSource).toHaveBeenCalledWith(
+      expect.objectContaining({ initArgs: { file }, initWorker: expect.any(Function) }),
+    );
+    expect(IterablePlayer).toHaveBeenCalledWith({
+      metricsCollector,
+      source: (WorkerIterableSource as jest.Mock).mock.instances[0],
+      name: "flight.ulg",
+      sourceId: "ulog-local-file",
+    });
+
+    const initWorker = (WorkerIterableSource as jest.Mock).mock.calls[0]![0]
+      .initWorker as () => unknown;
+    const WorkerMock = jest.fn();
+    (global as unknown as { Worker: typeof WorkerMock }).Worker = WorkerMock;
+    initWorker();
+    expect(WorkerMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/suite-base/src/dataSources/VelodyneDataSourceFactory.test.ts
+++ b/packages/suite-base/src/dataSources/VelodyneDataSourceFactory.test.ts
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import VelodynePlayer from "@lichtblick/suite-base/players/VelodynePlayer";
+
+import VelodyneDataSourceFactory from "./VelodyneDataSourceFactory";
+
+jest.mock("@lichtblick/suite-base/players/VelodynePlayer", () => jest.fn());
+
+describe("VelodyneDataSourceFactory", () => {
+  it("exposes the Lidar connection metadata and requires a port", () => {
+    const factory = new VelodyneDataSourceFactory();
+    expect(factory).toMatchObject({
+      id: "velodyne-device",
+      type: "connection",
+      displayName: "Velodyne Lidar",
+      formConfig: { fields: [{ id: "port", defaultValue: "2369" }] },
+    });
+    expect(factory.initialize({} as never)).toBeUndefined();
+  });
+
+  it("creates a player with the numeric UDP port and metrics collector", () => {
+    const factory = new VelodyneDataSourceFactory();
+    const metricsCollector = {} as never;
+    factory.initialize({ params: { port: "1234" }, metricsCollector } as never);
+    expect(VelodynePlayer).toHaveBeenCalledWith({ port: 1234, metricsCollector });
+  });
+});

--- a/packages/suite-base/src/hooks/useDefaultWebLaunchPreference.test.tsx
+++ b/packages/suite-base/src/hooks/useDefaultWebLaunchPreference.test.tsx
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { renderHook } from "@testing-library/react";
+
+import { useSessionStorageValue } from "@lichtblick/hooks";
+import { useMessagePipeline } from "@lichtblick/suite-base/components/MessagePipeline";
+import isDesktopApp from "@lichtblick/suite-base/util/isDesktopApp";
+
+import { useDefaultWebLaunchPreference } from "./useDefaultWebLaunchPreference";
+
+jest.mock("@lichtblick/hooks", () => ({ useSessionStorageValue: jest.fn() }));
+jest.mock("@lichtblick/suite-base/components/MessagePipeline", () => ({
+  useMessagePipeline: jest.fn(),
+}));
+jest.mock("@lichtblick/suite-base/util/isDesktopApp", () => jest.fn());
+
+describe("useDefaultWebLaunchPreference", () => {
+  const setPreference = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (isDesktopApp as jest.Mock).mockReturnValue(false);
+    (useSessionStorageValue as jest.Mock).mockReturnValue([undefined, setPreference]);
+  });
+
+  it("stores the web preference when a URL state is available", () => {
+    (useMessagePipeline as jest.Mock).mockReturnValue(true);
+    renderHook(() => useDefaultWebLaunchPreference());
+    expect(setPreference).toHaveBeenCalledWith("web");
+  });
+
+  it("does not overwrite an existing preference, missing URL state, or desktop preference", () => {
+    (useMessagePipeline as jest.Mock).mockReturnValue(false);
+    renderHook(() => useDefaultWebLaunchPreference());
+    expect(setPreference).not.toHaveBeenCalled();
+
+    (useSessionStorageValue as jest.Mock).mockReturnValue(["desktop", setPreference]);
+    (useMessagePipeline as jest.Mock).mockReturnValue(true);
+    renderHook(() => useDefaultWebLaunchPreference());
+    expect(setPreference).not.toHaveBeenCalled();
+
+    (useSessionStorageValue as jest.Mock).mockReturnValue([undefined, setPreference]);
+    (isDesktopApp as jest.Mock).mockReturnValue(true);
+    renderHook(() => useDefaultWebLaunchPreference());
+    expect(setPreference).not.toHaveBeenCalled();
+  });
+});

--- a/packages/suite-base/src/players/AnalyticsMetricsCollector.test.ts
+++ b/packages/suite-base/src/players/AnalyticsMetricsCollector.test.ts
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { AppEvent } from "@lichtblick/suite-base/services/IAnalytics";
+
+import AnalyticsMetricsCollector from "./AnalyticsMetricsCollector";
+import NoopMetricsCollector from "./NoopMetricsCollector";
+
+describe("player metrics collectors", () => {
+  it("merges persistent metadata with individual event data", () => {
+    const analytics = { logEvent: jest.fn().mockResolvedValue(undefined) };
+    const collector = new AnalyticsMetricsCollector(analytics as never);
+    collector.setProperty("source", "bag");
+    collector.setProperty("count", 1);
+    collector.logEvent(AppEvent.PLAYER_CONSTRUCTED, { count: 2, ready: true });
+    collector.playerConstructed();
+
+    expect(analytics.logEvent).toHaveBeenNthCalledWith(1, AppEvent.PLAYER_CONSTRUCTED, {
+      source: "bag",
+      count: 2,
+      ready: true,
+    });
+    expect(analytics.logEvent).toHaveBeenNthCalledWith(2, AppEvent.PLAYER_CONSTRUCTED, {
+      source: "bag",
+      count: 1,
+    });
+  });
+
+  it("provides no-op metrics methods when analytics is unavailable", () => {
+    const collector = new NoopMetricsCollector();
+    expect(() => {
+      collector.setProperty("anything", true);
+      collector.playerConstructed();
+    }).not.toThrow();
+  });
+});

--- a/packages/suite-base/src/players/IterablePlayer/IteratorCursor.test.ts
+++ b/packages/suite-base/src/players/IterablePlayer/IteratorCursor.test.ts
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { IteratorCursor } from "./IteratorCursor";
+
+async function* results(values: readonly unknown[]) {
+  yield* values as never;
+}
+
+const stamp = (sec: number) => ({ type: "stamp" as const, stamp: { sec, nsec: 0 } });
+const problem = { type: "problem" as const, connectionId: 1, problem: { message: "problem" } };
+const message = (sec: number) =>
+  ({ type: "message-event" as const, msgEvent: { receiveTime: { sec, nsec: 0 } } }) as never;
+
+describe("IteratorCursor", () => {
+  it("reads next values and batches through the time cutoff", async () => {
+    const cursor = new IteratorCursor(results([stamp(1), stamp(3), stamp(4)]));
+
+    await expect(cursor.next()).resolves.toEqual(stamp(1));
+    await expect(cursor.nextBatch(500)).resolves.toEqual([stamp(3), stamp(4)]);
+    await expect(cursor.nextBatch(500)).resolves.toBeUndefined();
+  });
+
+  it("ends a batch at a problem result", async () => {
+    const cursor = new IteratorCursor(results([stamp(1), problem, stamp(2)]));
+
+    await expect(cursor.nextBatch(1_000)).resolves.toEqual([stamp(1), problem]);
+    await expect(cursor.next()).resolves.toEqual(stamp(2));
+  });
+
+  it("handles a problem as the first batch result and message-event cutoffs", async () => {
+    await expect(new IteratorCursor(results([problem])).nextBatch(1_000)).resolves.toEqual([
+      problem,
+    ]);
+    await expect(
+      new IteratorCursor(results([message(1), message(3)])).nextBatch(1_000),
+    ).resolves.toEqual([message(1), message(3)]);
+  });
+
+  it("keeps the first value past a read-until boundary for the next call", async () => {
+    const cursor = new IteratorCursor(results([stamp(1), stamp(3), stamp(4)]));
+
+    await expect(cursor.readUntil({ sec: 2, nsec: 0 })).resolves.toEqual([stamp(1)]);
+    await expect(cursor.readUntil({ sec: 2, nsec: 0 })).resolves.toEqual([]);
+    await expect(cursor.readUntil({ sec: 4, nsec: 0 })).resolves.toEqual([stamp(3)]);
+    await expect(
+      new IteratorCursor(results([stamp(1)])).readUntil({ sec: 2, nsec: 0 }),
+    ).resolves.toEqual([stamp(1)]);
+  });
+
+  it("returns undefined when aborted and closes iterators", async () => {
+    const controller = new AbortController();
+    const iterator = results([stamp(1)]);
+    const returnSpy = jest.spyOn(iterator, "return");
+    const cursor = new IteratorCursor(iterator, controller.signal);
+
+    controller.abort();
+    await expect(cursor.next()).resolves.toBeUndefined();
+    await expect(cursor.readUntil({ sec: 1, nsec: 0 })).resolves.toBeUndefined();
+    await cursor.end();
+    expect(returnSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/suite-base/src/players/TopicAliasingPlayer/BlockTopicProcessor.test.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/BlockTopicProcessor.test.ts
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { BlockTopicProcessor } from "./BlockTopicProcessor";
+
+describe("BlockTopicProcessor", () => {
+  it("aliases every original-topic event for each alias", () => {
+    const processor = new BlockTopicProcessor("/source", ["/alias-a", "/alias-b"]);
+    const source = [{ topic: "/source", message: { value: 1 } }];
+
+    expect(processor.aliasBlock({ messagesByTopic: { "/source": source } } as never, 0)).toEqual({
+      "/alias-a": [{ topic: "/alias-a", message: { value: 1 } }],
+      "/alias-b": [{ topic: "/alias-b", message: { value: 1 } }],
+    });
+  });
+
+  it("returns stable aliases for unchanged input and replaces them after input changes", () => {
+    const processor = new BlockTopicProcessor("/source", ["/alias"]);
+    const source = [{ topic: "/source" }];
+    const block = { messagesByTopic: { "/source": source } } as never;
+    const first = processor.aliasBlock(block, 3);
+    expect(processor.aliasBlock(block, 3)).toBe(first);
+
+    const second = processor.aliasBlock(
+      { messagesByTopic: { "/source": [{ topic: "/source", message: 2 }] } } as never,
+      3,
+    );
+    expect(second).not.toBe(first);
+    expect(second["/alias"]).toEqual([{ topic: "/alias", message: 2 }]);
+  });
+
+  it("clears cached aliases when a block has no original topic", () => {
+    const processor = new BlockTopicProcessor("/source", ["/alias"]);
+    processor.aliasBlock({ messagesByTopic: { "/source": [{ topic: "/source" }] } } as never, 1);
+    expect(processor.aliasBlock({ messagesByTopic: {} } as never, 1)).toEqual({});
+  });
+});

--- a/packages/suite-base/src/players/TopicAliasingPlayer/NoopStateProcessor.test.ts
+++ b/packages/suite-base/src/players/TopicAliasingPlayer/NoopStateProcessor.test.ts
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { NoopStateProcessor } from "./NoopStateProcessor";
+
+describe("NoopStateProcessor", () => {
+  it("preserves player state and subscriptions by reference", () => {
+    const processor = new NoopStateProcessor();
+    const state = { name: "player" } as never;
+    const subscriptions = [{ topic: "/foo" }] as never;
+
+    expect(processor.process(state, subscriptions)).toBe(state);
+    expect(processor.aliasSubscriptions(subscriptions)).toBe(subscriptions);
+  });
+});

--- a/packages/suite-base/src/providers/CurrentLayoutProvider/toggleSelectedPanel.test.ts
+++ b/packages/suite-base/src/providers/CurrentLayoutProvider/toggleSelectedPanel.test.ts
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import toggleSelectedPanel from "./toggleSelectedPanel";
+
+describe("toggleSelectedPanel", () => {
+  it("toggles an ordinary selected panel", () => {
+    expect(toggleSelectedPanel("Plot!one", undefined, {}, [])).toEqual(["Plot!one"]);
+    expect(toggleSelectedPanel("Plot!one", undefined, {}, ["Plot!one"])).toEqual([]);
+  });
+
+  it("deselects all children of a selected tab panel", () => {
+    const configs = {
+      "Tab!parent": {
+        activeTabIdx: 0,
+        tabs: [
+          { title: "Tab", layout: { direction: "row", first: "Plot!one", second: "Plot!two" } },
+        ],
+      },
+    } as never;
+
+    expect(toggleSelectedPanel("Tab!parent", undefined, configs, ["Plot!one", "Plot!two"])).toEqual(
+      ["Tab!parent"],
+    );
+  });
+
+  it("deselects all ancestor tab panels when selecting a child", () => {
+    const configs = {
+      "Tab!outer": { activeTabIdx: 0, tabs: [{ title: "Outer", layout: "Tab!inner" }] },
+      "Tab!inner": { activeTabIdx: 0, tabs: [{ title: "Inner", layout: "Plot!one" }] },
+    } as never;
+
+    expect(
+      toggleSelectedPanel("Plot!one", "Tab!inner", configs, ["Tab!outer", "Tab!inner"]),
+    ).toEqual(["Plot!one"]);
+  });
+});

--- a/packages/suite-base/src/providers/StudioLogsSettingsProvider/store.test.ts
+++ b/packages/suite-base/src/providers/StudioLogsSettingsProvider/store.test.ts
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Log from "@lichtblick/log";
+
+import { createStudioLogsSettingsStore } from "./store";
+
+describe("createStudioLogsSettingsStore", () => {
+  it("initializes, enables, and disables configured log channels", () => {
+    const prefix = `test-store-${Date.now()}`;
+    const first = Log.getLogger(`${prefix}/first`);
+    const second = Log.getLogger(`${prefix}/second`);
+    const store = createStudioLogsSettingsStore({
+      globalLevel: "debug",
+      disabledChannels: [first.name()],
+    });
+
+    expect(store.getState().globalLevel).toBe("debug");
+    expect(store.getState().channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: first.name(), enabled: false }),
+        expect.objectContaining({ name: second.name(), enabled: true }),
+      ]),
+    );
+
+    store.getState().enableChannel(first.name());
+    expect(store.getState().channels).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: first.name(), enabled: true })]),
+    );
+    store.getState().disableChannel(second.name());
+    expect(store.getState().channels).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: second.name(), enabled: false })]),
+    );
+  });
+
+  it("updates global and prefix log levels", () => {
+    const prefix = `test-prefix-${Date.now()}`;
+    const first = Log.getLogger(`${prefix}/first`);
+    const second = Log.getLogger(`${prefix}/second`);
+    const store = createStudioLogsSettingsStore();
+
+    store.getState().setGlobalLevel("error");
+    expect(store.getState().globalLevel).toBe("error");
+    store.getState().enablePrefix(prefix);
+    expect(store.getState().channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: first.name(), enabled: true }),
+        expect.objectContaining({ name: second.name(), enabled: true }),
+      ]),
+    );
+    store.getState().setGlobalLevel("debug");
+    store.getState().disablePrefix(prefix);
+    expect(store.getState().channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: first.name(), enabled: false }),
+        expect.objectContaining({ name: second.name(), enabled: false }),
+      ]),
+    );
+  });
+});

--- a/packages/suite-base/src/reportError.test.ts
+++ b/packages/suite-base/src/reportError.test.ts
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { reportError, setReportErrorHandler } from "./reportError";
+
+describe("reportError", () => {
+  afterEach(() => {
+    delete (global as { foxgloveStudioReportErrorFn?: unknown }).foxgloveStudioReportErrorFn;
+  });
+
+  it("does nothing until a handler is registered and then forwards the original error", () => {
+    const error = new Error("failed");
+    expect(() => reportError(error)).not.toThrow();
+
+    const handler = jest.fn();
+    setReportErrorHandler(handler);
+    reportError(error);
+    expect(handler).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/suite-base/src/services/ApiClient.test.ts
+++ b/packages/suite-base/src/services/ApiClient.test.ts
@@ -1,0 +1,223 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { ApiClient, ApiError, LocalStorageTokenStorage } from "./ApiClient";
+
+const response = (status: number, data: unknown, extra: Record<string, unknown> = {}) =>
+  ({
+    status,
+    ok: status >= 200 && status < 300,
+    json: jest.fn().mockResolvedValue(data),
+    blob: jest.fn().mockResolvedValue(new Blob(["download"])),
+    ...extra,
+  }) as never;
+
+class MockXmlHttpRequest {
+  public static status = 200;
+  public static responseText = '{"uploaded":true}';
+  public static event: "load" | "error" | "abort" = "load";
+  public readonly upload = { addEventListener: jest.fn() };
+  public status = MockXmlHttpRequest.status;
+  public responseText = MockXmlHttpRequest.responseText;
+  private readonly listeners = new Map<string, () => void>();
+
+  public addEventListener(type: string, callback: () => void): void {
+    this.listeners.set(type, callback);
+  }
+
+  public open = jest.fn();
+  public setRequestHeader = jest.fn();
+
+  public send = jest.fn(() => {
+    this.listeners.get(MockXmlHttpRequest.event)?.();
+  });
+}
+
+describe("ApiClient", () => {
+  const tokenStorage = {
+    getAccessToken: jest.fn(),
+    getRefreshToken: jest.fn(),
+    setTokens: jest.fn(),
+    clearTokens: jest.fn(),
+  };
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(globalThis, { fetch: fetchMock });
+  });
+
+  it("normalizes URLs and persists local storage tokens", () => {
+    const storage = new LocalStorageTokenStorage();
+    storage.setTokens("access", "refresh");
+    expect(storage.getAccessToken()).toBe("access");
+    expect(storage.getRefreshToken()).toBe("refresh");
+    storage.clearTokens();
+    expect(storage.getAccessToken()).toBeUndefined();
+    expect(storage.getRefreshToken()).toBeUndefined();
+
+    const client = new ApiClient("https://api.example/", tokenStorage);
+    expect(client.getBaseUrl()).toBe("https://api.example");
+    client.setBaseUrl("https://other.example/");
+    expect(client.getBaseUrl()).toBe("https://other.example");
+  });
+
+  it("serializes authenticated requests and all HTTP helper methods", async () => {
+    tokenStorage.getAccessToken.mockReturnValue("access");
+    fetchMock.mockResolvedValue(response(200, { ok: true }));
+    const client = new ApiClient("https://api.example", tokenStorage);
+
+    await expect(client.get("/get", { headers: { Accept: "application/json" } })).resolves.toEqual({
+      ok: true,
+    });
+    await client.post("/post", { value: 1 });
+    await client.put("/put", { value: 2 });
+    await client.patch("/patch", { value: 3 });
+    await client.delete("/delete");
+    await client.request("/anonymous", { skipAuth: true });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "https://api.example/get", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: "Bearer access",
+      },
+      body: undefined,
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example/post",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ value: 1 }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenLastCalledWith("https://api.example/anonymous", {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      body: undefined,
+    });
+    expect(client.getAccessToken()).toBe("access");
+  });
+
+  it("maps unsuccessful API responses to ApiError", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(400, { error: { code: "BAD", message: "Bad request" } }))
+      .mockResolvedValueOnce(response(500, {}));
+    const client = new ApiClient("https://api.example", tokenStorage);
+
+    await expect(client.get("/bad")).rejects.toMatchObject<ApiError>({
+      name: "ApiError",
+      code: "BAD",
+      statusCode: 400,
+      message: "Bad request",
+    });
+    await expect(client.get("/unknown")).rejects.toMatchObject<ApiError>({
+      code: "UNKNOWN_ERROR",
+      message: "An unknown error occurred",
+      statusCode: 500,
+    });
+  });
+
+  it("refreshes and retries an unauthorized request", async () => {
+    tokenStorage.getAccessToken.mockReturnValue("old");
+    tokenStorage.getRefreshToken.mockReturnValue("refresh");
+    fetchMock
+      .mockResolvedValueOnce(response(401, {}))
+      .mockResolvedValueOnce(response(200, { accessToken: "new", refreshToken: "new-refresh" }))
+      .mockResolvedValueOnce(response(200, { value: "retried" }));
+    const client = new ApiClient("https://api.example", tokenStorage);
+
+    await expect(client.get("/protected")).resolves.toEqual({ value: "retried" });
+    expect(tokenStorage.setTokens).toHaveBeenCalledWith("new", "new-refresh");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example/api/auth/refresh",
+      expect.any(Object),
+    );
+  });
+
+  it("notifies on failed refresh and clears invalid tokens", async () => {
+    const onExpired = jest.fn();
+    tokenStorage.getRefreshToken.mockReturnValue("refresh");
+    fetchMock.mockResolvedValueOnce(response(401, {})).mockResolvedValueOnce(response(403, {}));
+    const client = new ApiClient("https://api.example", tokenStorage);
+    client.setSessionExpiredCallback(onExpired);
+
+    await expect(client.get("/protected")).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+      statusCode: 401,
+    });
+    expect(tokenStorage.clearTokens).toHaveBeenCalledTimes(1);
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploads and downloads files with authenticated headers and errors", async () => {
+    tokenStorage.getAccessToken.mockReturnValue("access");
+    const formData = new FormData();
+    formData.append("file", new Blob(["upload"]));
+    fetchMock
+      .mockResolvedValueOnce(response(200, { uploaded: true }))
+      .mockResolvedValueOnce(
+        response(200, {}, { blob: jest.fn().mockResolvedValue(new Blob(["file"])) }),
+      )
+      .mockResolvedValueOnce(response(404, { error: { code: "MISSING", message: "Not found" } }))
+      .mockResolvedValueOnce({
+        status: 500,
+        ok: false,
+        json: jest.fn().mockRejectedValue(new Error("not json")),
+      });
+    const client = new ApiClient("https://api.example", tokenStorage);
+
+    await expect(client.uploadFile("/upload", formData)).resolves.toEqual({ uploaded: true });
+    await expect(client.downloadBlob("/download")).resolves.toBeInstanceOf(Blob);
+    await expect(client.uploadFile("/missing", formData)).rejects.toMatchObject({
+      code: "MISSING",
+    });
+    await expect(client.downloadBlob("/failed")).rejects.toMatchObject({
+      code: "DOWNLOAD_ERROR",
+      message: "Download failed",
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example/upload",
+      expect.objectContaining({
+        method: "POST",
+        headers: { Authorization: "Bearer access" },
+      }),
+    );
+  });
+
+  it("reports XMLHttpRequest upload success, malformed responses, and transport failures", async () => {
+    Object.assign(globalThis, { XMLHttpRequest: MockXmlHttpRequest });
+    tokenStorage.getAccessToken.mockReturnValue("access");
+    const client = new ApiClient("https://api.example", tokenStorage);
+
+    MockXmlHttpRequest.status = 201;
+    MockXmlHttpRequest.responseText = '{"uploaded":true}';
+    MockXmlHttpRequest.event = "load";
+    await expect(
+      client.uploadFileWithProgress("/upload", new FormData(), jest.fn()),
+    ).resolves.toEqual({
+      uploaded: true,
+    });
+
+    MockXmlHttpRequest.status = 200;
+    MockXmlHttpRequest.responseText = "not json";
+    await expect(client.uploadFileWithProgress("/upload", new FormData())).rejects.toMatchObject({
+      code: "PARSE_ERROR",
+      statusCode: 200,
+    });
+
+    MockXmlHttpRequest.event = "error";
+    await expect(client.uploadFileWithProgress("/upload", new FormData())).rejects.toMatchObject({
+      code: "NETWORK_ERROR",
+    });
+    MockXmlHttpRequest.event = "abort";
+    await expect(client.uploadFileWithProgress("/upload", new FormData())).rejects.toMatchObject({
+      code: "ABORTED",
+    });
+  });
+});

--- a/packages/suite-base/src/services/AuthService.test.ts
+++ b/packages/suite-base/src/services/AuthService.test.ts
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { AuthService } from "./AuthService";
+
+const user = { id: "user", email: "user@example.com", name: "User" } as never;
+
+describe("AuthService", () => {
+  const apiClient = { get: jest.fn(), post: jest.fn() };
+  const tokenStorage = {
+    getAccessToken: jest.fn(),
+    getRefreshToken: jest.fn(),
+    setTokens: jest.fn(),
+    clearTokens: jest.fn(),
+  };
+  const service = new AuthService(apiClient as never, tokenStorage);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("logs in and registers with unauthenticated requests", async () => {
+    apiClient.post.mockResolvedValueOnce({ user, accessToken: "access", refreshToken: "refresh" });
+    await expect(service.login({ email: user.email, password: "secret" } as never)).resolves.toBe(
+      user,
+    );
+    expect(apiClient.post).toHaveBeenLastCalledWith(
+      "/api/auth/login",
+      { email: user.email, password: "secret" },
+      { skipAuth: true },
+    );
+
+    apiClient.post.mockResolvedValueOnce({
+      user,
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+    });
+    await expect(
+      service.register({ email: user.email, password: "secret" } as never),
+    ).resolves.toBe(user);
+    expect(tokenStorage.setTokens).toHaveBeenLastCalledWith("new-access", "new-refresh");
+  });
+
+  it("clears tokens on logout whether or not the server accepts it", async () => {
+    tokenStorage.getRefreshToken.mockReturnValueOnce("refresh");
+    apiClient.post.mockRejectedValueOnce(new Error("expired"));
+    await service.logout();
+    expect(apiClient.post).toHaveBeenCalledWith("/api/auth/logout", { refreshToken: "refresh" });
+    expect(tokenStorage.clearTokens).toHaveBeenCalledTimes(1);
+
+    await service.logout();
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the current user and refreshes a valid session", async () => {
+    apiClient.get.mockResolvedValueOnce(user);
+    await expect(service.getCurrentUser()).resolves.toBe(user);
+    expect(apiClient.get).toHaveBeenCalledWith("/api/auth/me");
+
+    tokenStorage.getRefreshToken.mockReturnValueOnce("refresh");
+    apiClient.post.mockResolvedValueOnce({ accessToken: "access", refreshToken: "next-refresh" });
+    await service.refreshTokens();
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/auth/refresh",
+      { refreshToken: "refresh" },
+      { skipAuth: true },
+    );
+    expect(tokenStorage.setTokens).toHaveBeenLastCalledWith("access", "next-refresh");
+  });
+
+  it("rejects refresh without a token and reports session availability", async () => {
+    await expect(service.refreshTokens()).rejects.toThrow("No refresh token available");
+    tokenStorage.getAccessToken.mockReturnValueOnce(undefined);
+    expect(service.hasValidSession()).toBe(false);
+    tokenStorage.getAccessToken.mockReturnValueOnce("access");
+    expect(service.hasValidSession()).toBe(true);
+  });
+});

--- a/packages/suite-base/src/services/DeviceService.test.ts
+++ b/packages/suite-base/src/services/DeviceService.test.ts
@@ -1,0 +1,209 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { DeviceService } from "./DeviceService";
+
+const device = {
+  id: "device-1",
+  name: "Device",
+  type: "robot",
+  model: null,
+  serialNumber: null,
+  firmwareVersion: null,
+  location: null,
+  ipAddress: null,
+  status: "online" as const,
+  enabled: true,
+  lastSeen: null,
+  agentVersion: null,
+  agentStatus: null,
+  agentUptime: null,
+  cpuUsage: null,
+  memoryUsage: null,
+  diskUsage: null,
+  rosDistro: null,
+  rosNodeCount: null,
+  rosTopicCount: null,
+  createdAt: "created",
+  updatedAt: "updated",
+};
+
+describe("DeviceService", () => {
+  const apiClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    request: jest.fn(),
+    delete: jest.fn(),
+  };
+  const service = new DeviceService(apiClient as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("serializes device list filters and converts nullable API fields", async () => {
+    apiClient.get.mockResolvedValue({ data: [device], total: 1, page: 2, pageSize: 20 });
+
+    const result = await service.getDevices({
+      orgId: "org",
+      search: "robot",
+      status: "online",
+      page: 2,
+      pageSize: 20,
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/devices?orgId=org&search=robot&status=online&page=2&pageSize=20",
+    );
+    expect(result).toMatchObject({
+      data: [
+        {
+          id: "device-1",
+          model: undefined,
+          serialNumber: undefined,
+          agentStatus: undefined,
+        },
+      ],
+      total: 1,
+      page: 2,
+      pageSize: 20,
+    });
+  });
+
+  it("uses the base endpoint without optional device filters", async () => {
+    apiClient.get.mockResolvedValue({ data: [], total: 0, page: 1, pageSize: 10 });
+
+    await service.getDevices();
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/devices");
+  });
+
+  it("maps device CRUD, topic, token, and agent endpoints", async () => {
+    apiClient.get
+      .mockResolvedValueOnce({ data: device })
+      .mockResolvedValueOnce({
+        data: [{ id: "topic", name: "/topic", type: "std_msgs/String", frequency: null }],
+      })
+      .mockResolvedValueOnce({
+        data: {
+          agentInfo: { version: null, status: null, uptime: null, lastHeartbeat: null },
+          systemInfo: {
+            cpuUsage: null,
+            memoryUsage: null,
+            diskUsage: null,
+            rosDistro: null,
+            rosNodeCount: null,
+            rosTopicCount: null,
+          },
+        },
+      });
+    apiClient.request.mockResolvedValue({ data: device });
+    apiClient.post
+      .mockResolvedValueOnce({ data: device })
+      .mockResolvedValueOnce({ data: { token: "token" } });
+    apiClient.delete.mockResolvedValue({ success: true });
+
+    await expect(service.getDevice("id")).resolves.toMatchObject({
+      id: "device-1",
+      model: undefined,
+    });
+    await expect(service.updateDevice("id", { name: "updated" } as never)).resolves.toMatchObject({
+      id: "device-1",
+    });
+    await expect(service.enableDevice("id")).resolves.toMatchObject({ id: "device-1" });
+    await expect(service.deleteDevice("id")).resolves.toBe(true);
+    await expect(service.getDeviceTopics("id")).resolves.toEqual([
+      { id: "topic", name: "/topic", type: "std_msgs/String", frequency: undefined },
+    ]);
+    await expect(service.generateDeviceToken("id")).resolves.toEqual({ token: "token" });
+    await expect(service.getDeviceAgentInfo("id")).resolves.toEqual({
+      agentInfo: {
+        version: undefined,
+        status: undefined,
+        uptime: undefined,
+        lastHeartbeat: undefined,
+      },
+      systemInfo: {
+        cpuUsage: undefined,
+        memoryUsage: undefined,
+        diskUsage: undefined,
+        rosDistro: undefined,
+        rosNodeCount: undefined,
+        rosTopicCount: undefined,
+      },
+    });
+    expect(apiClient.request).toHaveBeenCalledWith("/api/devices/id", {
+      method: "PUT",
+      body: { name: "updated" },
+    });
+  });
+
+  it("converts registration information without optional system information", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        code: "code",
+        machineId: "machine",
+        hostname: null,
+        platform: null,
+        ipAddress: null,
+        systemInfo: null,
+        expiresAt: "later",
+        expiresIn: 60,
+      },
+    });
+
+    await expect(service.getDeviceRegistrationInfo("a b")).resolves.toEqual({
+      code: "code",
+      machineId: "machine",
+      hostname: undefined,
+      platform: undefined,
+      ipAddress: undefined,
+      systemInfo: undefined,
+      expiresAt: "later",
+      expiresIn: 60,
+    });
+    expect(apiClient.get).toHaveBeenCalledWith("/api/device/register/info?code=a%20b");
+  });
+
+  it("serializes device event filters and maps event mutation responses", async () => {
+    const event = {
+      id: "event",
+      deviceId: "device",
+      eventType: "maintenance" as const,
+      description: "service",
+      startTime: "start",
+      duration: 5,
+      metadata: { source: "test" },
+      createdBy: "user",
+      createdAt: "created",
+      updatedAt: "updated",
+    };
+    apiClient.get.mockResolvedValue({ data: [event], total: 1, page: 3, pageSize: 10 });
+    apiClient.post.mockResolvedValue({ data: event });
+    apiClient.request.mockResolvedValue({ data: event });
+    apiClient.delete.mockResolvedValue({ success: true });
+
+    await expect(
+      service.getDeviceEvents("device", {
+        eventType: "maintenance",
+        startDate: "start",
+        endDate: "end",
+        page: 3,
+        pageSize: 10,
+      }),
+    ).resolves.toMatchObject({ data: [event], total: 1, page: 3, pageSize: 10 });
+    await expect(
+      service.createDeviceEvent("device", { description: "service" } as never),
+    ).resolves.toEqual(event);
+    await expect(
+      service.updateDeviceEvent("device", "event", { description: "updated" } as never),
+    ).resolves.toEqual(event);
+    await expect(service.deleteDeviceEvent("device", "event")).resolves.toBe(true);
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/devices/device/events?eventType=maintenance&startDate=start&endDate=end&page=3&pageSize=10",
+    );
+    expect(apiClient.request).toHaveBeenCalledWith("/api/devices/device/events/event", {
+      method: "PATCH",
+      body: { description: "updated" },
+    });
+  });
+});

--- a/packages/suite-base/src/services/EventService.test.ts
+++ b/packages/suite-base/src/services/EventService.test.ts
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { EventService } from "./EventService";
+
+const event = {
+  id: "event-1",
+  deviceId: "device-1",
+  deviceName: null,
+  eventType: "maintenance" as const,
+  description: "Replace battery",
+  startTime: "2026-07-20T00:00:00Z",
+  duration: 30,
+  metadata: { source: "test" },
+  createdBy: "user-1",
+  createdAt: "2026-07-20T00:00:00Z",
+  updatedAt: "2026-07-20T00:00:00Z",
+};
+
+describe("EventService", () => {
+  const apiClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  };
+  const service = new EventService(apiClient as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("serializes all list filters and calculates total pages", async () => {
+    apiClient.get.mockResolvedValue({ data: [event], total: 21, page: 2, pageSize: 10 });
+
+    await expect(
+      service.getEvents({
+        orgId: "org",
+        deviceId: "device",
+        eventType: "maintenance",
+        startDate: "start",
+        endDate: "end",
+        search: "battery",
+        page: 2,
+        pageSize: 10,
+      }),
+    ).resolves.toEqual({
+      events: [event],
+      totalEvents: 21,
+      page: 2,
+      pageSize: 10,
+      totalPages: 3,
+    });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/events?orgId=org&page=2&pageSize=10&deviceId=device&eventType=maintenance&startDate=start&endDate=end&search=battery",
+    );
+  });
+
+  it("uses the base endpoint when no list filters are supplied", async () => {
+    apiClient.get.mockResolvedValue({ data: [], total: 0, page: 1, pageSize: 20 });
+
+    await service.getEvents();
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/events");
+  });
+
+  it("maps event CRUD API responses", async () => {
+    apiClient.get.mockResolvedValue({ data: event });
+    apiClient.post.mockResolvedValue({ data: event });
+    apiClient.patch.mockResolvedValue({ data: event });
+    apiClient.delete.mockResolvedValue(undefined);
+
+    await expect(service.getEvent("event-1")).resolves.toEqual(event);
+    await expect(service.createEvent({ description: "Replace battery" } as never)).resolves.toEqual(
+      event,
+    );
+    await expect(service.updateEvent("event-1", { duration: 45 })).resolves.toEqual(event);
+    await expect(service.deleteEvent("event-1")).resolves.toBe(true);
+    expect(apiClient.get).toHaveBeenCalledWith("/api/events/event-1");
+    expect(apiClient.post).toHaveBeenCalledWith("/api/events", { description: "Replace battery" });
+    expect(apiClient.patch).toHaveBeenCalledWith("/api/events/event-1", { duration: 45 });
+    expect(apiClient.delete).toHaveBeenCalledWith("/api/events/event-1");
+  });
+});

--- a/packages/suite-base/src/services/FloraRemoteLayoutStorage.test.ts
+++ b/packages/suite-base/src/services/FloraRemoteLayoutStorage.test.ts
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { FloraRemoteLayoutStorage } from "./FloraRemoteLayoutStorage";
+
+const layout = {
+  id: "layout-1",
+  name: "Layout",
+  permission: "PRIVATE",
+  data: { configById: {}, layout: "" },
+  savedAt: "2026-07-20T00:00:00Z",
+  orgId: null,
+  createdAt: "created",
+  updatedAt: "updated",
+};
+
+describe("FloraRemoteLayoutStorage", () => {
+  const apiClient = { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("uses user and organization namespaces when listing layouts", async () => {
+    apiClient.get.mockResolvedValue([layout]);
+    const userStorage = new FloraRemoteLayoutStorage(apiClient as never, "user");
+    const orgStorage = new FloraRemoteLayoutStorage(apiClient as never, "user", "org");
+
+    await expect(userStorage.getLayouts()).resolves.toEqual([
+      expect.objectContaining({ id: "layout-1", savedAt: layout.savedAt }),
+    ]);
+    await expect(orgStorage.getLayouts()).resolves.toEqual([
+      expect.objectContaining({ id: "layout-1" }),
+    ]);
+    expect(userStorage.namespace).toBe("user");
+    expect(orgStorage.namespace).toBe("org-org");
+    expect(apiClient.get).toHaveBeenNthCalledWith(1, "/api/layouts");
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, "/api/layouts?orgId=org");
+  });
+
+  it("handles layout reads, saves, updates, conflicts, and deletion", async () => {
+    const storage = new FloraRemoteLayoutStorage(apiClient as never, "user", "org");
+    apiClient.get
+      .mockResolvedValueOnce(layout)
+      .mockRejectedValueOnce(new Error("layout not found"))
+      .mockRejectedValueOnce(new Error("network error"));
+    apiClient.post.mockResolvedValue(layout);
+    apiClient.put
+      .mockResolvedValueOnce({ status: "success", newLayout: layout })
+      .mockResolvedValueOnce({
+        status: "conflict",
+      });
+    apiClient.delete.mockResolvedValue({ deleted: false });
+
+    await expect(storage.getLayout("layout-1" as never)).resolves.toEqual(
+      expect.objectContaining({ name: "Layout" }),
+    );
+    await expect(storage.getLayout("missing" as never)).resolves.toBeUndefined();
+    await expect(storage.getLayout("broken" as never)).rejects.toThrow("network error");
+    await expect(
+      storage.saveNewLayout({
+        id: undefined,
+        name: "Layout",
+        data: layout.data as never,
+        permission: "PRIVATE" as never,
+        savedAt: layout.savedAt as never,
+      }),
+    ).resolves.toEqual(expect.objectContaining({ id: "layout-1" }));
+    await expect(
+      storage.updateLayout({
+        id: "layout-1" as never,
+        name: "Updated",
+        savedAt: layout.savedAt as never,
+      }),
+    ).resolves.toEqual({
+      status: "success",
+      newLayout: expect.objectContaining({ id: "layout-1" }),
+    });
+    await expect(
+      storage.updateLayout({ id: "layout-1" as never, savedAt: layout.savedAt as never }),
+    ).resolves.toEqual({ status: "conflict" });
+    await expect(storage.deleteLayout("layout-1" as never)).resolves.toBe(false);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/layouts",
+      expect.objectContaining({ orgId: "org" }),
+    );
+    expect(apiClient.delete).toHaveBeenCalledWith("/api/layouts/layout-1");
+  });
+});

--- a/packages/suite-base/src/services/IdbExtensionStorage.test.ts
+++ b/packages/suite-base/src/services/IdbExtensionStorage.test.ts
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { StoredExtension } from "./IExtensionStorage";
+import { IdbExtensionStorage } from "./IdbExtensionStorage";
+
+const makeExtension = (id: string): StoredExtension => ({
+  info: {
+    id,
+    description: "Test extension",
+    displayName: "Test extension",
+    homepage: "https://example.com",
+    keywords: [],
+    license: "MIT",
+    name: id,
+    publisher: "Test",
+    qualifiedName: `local:Test:${id}`,
+    version: "1.0.0",
+  },
+  content: new Uint8Array([1, 2, 3]),
+});
+
+describe("IdbExtensionStorage", () => {
+  it("stores extension metadata and content in its namespace", async () => {
+    const namespace = `extensions-${Date.now()}`;
+    const storage = new IdbExtensionStorage(namespace);
+    const first = makeExtension("first");
+    const second = makeExtension("second");
+
+    await expect(storage.put(first)).resolves.toEqual(first);
+    await storage.put(second);
+
+    await expect(storage.list()).resolves.toEqual(
+      expect.arrayContaining([first.info, second.info]),
+    );
+    await expect(storage.get(first.info.id)).resolves.toEqual(first);
+    await expect(storage.get("missing")).resolves.toBeUndefined();
+
+    await storage.delete(first.info.id);
+    await expect(storage.get(first.info.id)).resolves.toBeUndefined();
+    await expect(storage.list()).resolves.toEqual([second.info]);
+  });
+});

--- a/packages/suite-base/src/services/LayoutManager/MockLayoutManager.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/MockLayoutManager.test.ts
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import MockLayoutManager from "./MockLayoutManager";
+
+describe("MockLayoutManager", () => {
+  it("provides neutral state and independently callable manager operations", async () => {
+    const manager = new MockLayoutManager();
+    expect(manager).toMatchObject({
+      supportsSharing: false,
+      isBusy: false,
+      isOnline: false,
+      error: undefined,
+    });
+    await expect(manager.getLayouts()).resolves.toEqual([]);
+
+    manager.on("change" as never, jest.fn());
+    manager.off("change" as never, jest.fn());
+    manager.setError(new Error("failed"));
+    manager.setOnline(true);
+    manager.getLayout("layout" as never);
+    manager.saveNewLayout({} as never);
+    manager.updateLayout({} as never);
+    manager.deleteLayout("layout" as never);
+    manager.overwriteLayout({} as never);
+    manager.revertLayout("layout" as never);
+    manager.makePersonalCopy("layout" as never);
+    manager.syncWithRemote();
+
+    expect(manager.on).toHaveBeenCalledTimes(1);
+    expect(manager.syncWithRemote).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/suite-base/src/services/LayoutManager/NamespacedLayoutStorage.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/NamespacedLayoutStorage.test.ts
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { NamespacedLayoutStorage } from "./NamespacedLayoutStorage";
+
+const layout = { id: "layout", name: "Layout" } as never;
+
+describe("NamespacedLayoutStorage", () => {
+  const storage = {
+    list: jest.fn(),
+    get: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    migrateUnnamespacedLayouts: jest.fn(),
+    importLayouts: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage.migrateUnnamespacedLayouts.mockResolvedValue(undefined);
+    storage.importLayouts.mockResolvedValue(undefined);
+  });
+
+  it("waits for migrations before delegating all storage operations", async () => {
+    storage.list.mockResolvedValue([layout]);
+    storage.get.mockResolvedValue(layout);
+    storage.put.mockResolvedValue(layout);
+    const namespaced = new NamespacedLayoutStorage(storage as never, "target", {
+      migrateUnnamespacedLayouts: true,
+      importFromNamespace: "source",
+    });
+
+    await expect(namespaced.list()).resolves.toEqual([layout]);
+    await expect(namespaced.get("layout" as never)).resolves.toBe(layout);
+    await expect(namespaced.put(layout)).resolves.toBe(layout);
+    await expect(namespaced.delete("layout" as never)).resolves.toBeUndefined();
+
+    expect(storage.migrateUnnamespacedLayouts).toHaveBeenCalledWith("target");
+    expect(storage.importLayouts).toHaveBeenCalledWith({
+      fromNamespace: "source",
+      toNamespace: "target",
+    });
+    expect(storage.list).toHaveBeenCalledWith("target");
+    expect(storage.get).toHaveBeenCalledWith("target", "layout");
+    expect(storage.put).toHaveBeenCalledWith("target", layout);
+    expect(storage.delete).toHaveBeenCalledWith("target", "layout");
+  });
+
+  it("continues operations after an optional migration fails", async () => {
+    storage.migrateUnnamespacedLayouts.mockRejectedValueOnce(new Error("migration failed"));
+    storage.importLayouts.mockRejectedValueOnce(new Error("import failed"));
+    storage.list.mockResolvedValue([]);
+    const namespaced = new NamespacedLayoutStorage(storage as never, "target", {
+      migrateUnnamespacedLayouts: true,
+      importFromNamespace: "source",
+    });
+
+    await expect(namespaced.list()).resolves.toEqual([]);
+    (console.error as jest.Mock).mockClear();
+  });
+
+  it("skips optional migrations when neither was requested", async () => {
+    storage.get.mockResolvedValue(undefined);
+    const namespaced = new NamespacedLayoutStorage(storage as never, "target", {
+      migrateUnnamespacedLayouts: false,
+      importFromNamespace: undefined,
+    });
+
+    await expect(namespaced.get("missing" as never)).resolves.toBeUndefined();
+    expect(storage.migrateUnnamespacedLayouts).not.toHaveBeenCalled();
+    expect(storage.importLayouts).not.toHaveBeenCalled();
+  });
+});

--- a/packages/suite-base/src/services/LayoutManager/WriteThroughLayoutCache.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/WriteThroughLayoutCache.test.ts
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import WriteThroughLayoutCache from "./WriteThroughLayoutCache";
+
+const one = { id: "one", name: "One" } as never;
+const two = { id: "two", name: "Two" } as never;
+
+describe("WriteThroughLayoutCache", () => {
+  const storage = {
+    list: jest.fn(),
+    get: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    importLayouts: jest.fn(),
+    migrateUnnamespacedLayouts: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage.list.mockResolvedValue([one]);
+    storage.put.mockImplementation(async (_namespace, layout) => layout);
+  });
+
+  it("loads each namespace once and updates its in-memory view after writes", async () => {
+    const cache = new WriteThroughLayoutCache(storage as never);
+    await expect(cache.list("personal")).resolves.toEqual([one]);
+    await expect(cache.get("personal", "one" as never)).resolves.toBe(one);
+    expect(storage.list).toHaveBeenCalledTimes(1);
+
+    await expect(cache.put("personal", two)).resolves.toBe(two);
+    await expect(cache.list("personal")).resolves.toEqual([one, two]);
+    await cache.delete("personal", "one" as never);
+    await expect(cache.get("personal", "one" as never)).resolves.toBeUndefined();
+    expect(storage.delete).toHaveBeenCalledWith("personal", "one");
+  });
+
+  it("keeps independent namespace caches and delegates migration operations", async () => {
+    const cache = new WriteThroughLayoutCache(storage as never);
+    await cache.list("personal");
+    await cache.list("organization");
+    expect(storage.list).toHaveBeenCalledTimes(2);
+
+    await cache.importLayouts({ fromNamespace: "old", toNamespace: "new" });
+    await cache.migrateUnnamespacedLayouts("new");
+    expect(storage.importLayouts).toHaveBeenCalledWith({
+      fromNamespace: "old",
+      toNamespace: "new",
+    });
+    expect(storage.migrateUnnamespacedLayouts).toHaveBeenCalledWith("new");
+  });
+});

--- a/packages/suite-base/src/services/LayoutManager/computeLayoutSyncOperations.test.ts
+++ b/packages/suite-base/src/services/LayoutManager/computeLayoutSyncOperations.test.ts
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { Layout } from "@lichtblick/suite-base/services/ILayoutStorage";
+import { RemoteLayout } from "@lichtblick/suite-base/services/IRemoteLayoutStorage";
+
+import computeLayoutSyncOperations from "./computeLayoutSyncOperations";
+
+const makeLocal = (overrides: Partial<Layout> = {}): Layout =>
+  ({
+    id: "layout",
+    name: "Layout",
+    permission: "CREATOR_WRITE",
+    baseline: { data: { configById: {}, layout: "" }, savedAt: undefined },
+    working: undefined,
+    syncInfo: undefined,
+    ...overrides,
+  }) as Layout;
+
+const makeRemote = (overrides: Partial<RemoteLayout> = {}): RemoteLayout =>
+  ({
+    id: "layout",
+    name: "Layout",
+    permission: "CREATOR_WRITE",
+    data: { configById: {}, layout: "" },
+    savedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  }) as RemoteLayout;
+
+describe("computeLayoutSyncOperations", () => {
+  afterEach(() => {
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("uploads untracked and updated local layouts that exist remotely", () => {
+    expect(computeLayoutSyncOperations([makeLocal()], [makeRemote()])).toMatchObject([
+      { type: "upload-new", local: false },
+    ]);
+    expect(
+      computeLayoutSyncOperations(
+        [makeLocal({ syncInfo: { status: "updated", lastRemoteSavedAt: undefined } })],
+        [makeRemote()],
+      ),
+    ).toMatchObject([{ type: "upload-updated", local: false }]);
+  });
+
+  it("updates a tracked layout baseline only when the remote save changes", () => {
+    const tracked = makeLocal({
+      syncInfo: { status: "tracked", lastRemoteSavedAt: "2026-01-01T00:00:00.000Z" as never },
+    });
+
+    expect(computeLayoutSyncOperations([tracked], [makeRemote()])).toEqual([]);
+    expect(
+      computeLayoutSyncOperations(
+        [tracked],
+        [makeRemote({ savedAt: "2026-01-02T00:00:00.000Z" as never })],
+      ),
+    ).toMatchObject([{ type: "update-baseline", local: true }]);
+    expect(computeLayoutSyncOperations([tracked], [makeRemote({ savedAt: undefined })])).toEqual(
+      [],
+    );
+  });
+
+  it("reconciles deleted and contradictory layouts that are still on the server", () => {
+    expect(
+      computeLayoutSyncOperations(
+        [makeLocal({ syncInfo: { status: "locally-deleted", lastRemoteSavedAt: undefined } })],
+        [makeRemote()],
+      ),
+    ).toMatchObject([{ type: "delete-remote", local: false }]);
+    expect(
+      computeLayoutSyncOperations(
+        [makeLocal({ syncInfo: { status: "remotely-deleted", lastRemoteSavedAt: undefined } })],
+        [makeRemote()],
+      ),
+    ).toEqual([]);
+  });
+
+  it("handles local layouts that no longer exist remotely", () => {
+    expect(computeLayoutSyncOperations([makeLocal()], [])).toMatchObject([
+      { type: "upload-new", local: false },
+    ]);
+    expect(
+      computeLayoutSyncOperations(
+        [makeLocal({ syncInfo: { status: "updated", lastRemoteSavedAt: undefined } })],
+        [],
+      ),
+    ).toMatchObject([{ type: "delete-local", local: true }]);
+    expect(
+      computeLayoutSyncOperations(
+        [makeLocal({ syncInfo: { status: "tracked", lastRemoteSavedAt: undefined } })],
+        [],
+      ),
+    ).toMatchObject([{ type: "delete-local", local: true }]);
+    expect(
+      computeLayoutSyncOperations(
+        [makeLocal({ syncInfo: { status: "locally-deleted", lastRemoteSavedAt: undefined } })],
+        [],
+      ),
+    ).toMatchObject([{ type: "delete-local", local: true }]);
+    expect(
+      computeLayoutSyncOperations(
+        [makeLocal({ syncInfo: { status: "remotely-deleted", lastRemoteSavedAt: undefined } })],
+        [],
+      ),
+    ).toMatchObject([{ type: "delete-local", local: true }]);
+  });
+
+  it("keeps shared layouts as deleted cache entries and adds remote-only layouts", () => {
+    const shared = makeLocal({
+      permission: "ORG_WRITE",
+      working: { data: { configById: {}, layout: "" }, savedAt: undefined },
+      syncInfo: { status: "updated", lastRemoteSavedAt: undefined },
+    });
+    expect(computeLayoutSyncOperations([shared], [])).toMatchObject([
+      { type: "mark-deleted", local: true },
+    ]);
+    expect(
+      computeLayoutSyncOperations([], [makeRemote({ id: "remote-only" as never })]),
+    ).toMatchObject([{ type: "add-to-cache", local: true }]);
+  });
+});

--- a/packages/suite-base/src/services/MockLayoutStorage.test.ts
+++ b/packages/suite-base/src/services/MockLayoutStorage.test.ts
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MockLayoutStorage from "./MockLayoutStorage";
+
+const layout = { id: "layout-1", name: "Initial" } as never;
+
+describe("MockLayoutStorage", () => {
+  it("keeps layouts isolated by namespace and supports mutations", async () => {
+    const storage = new MockLayoutStorage("default", [layout]);
+    const secondLayout = { id: "layout-2", name: "Second" } as never;
+
+    await expect(storage.list("default")).resolves.toEqual([layout]);
+    await expect(storage.get("default", "layout-1")).resolves.toEqual(layout);
+    await expect(storage.get("unknown", "layout-1")).resolves.toBeUndefined();
+    await expect(storage.put("other", secondLayout)).resolves.toEqual(secondLayout);
+    await expect(storage.list("other")).resolves.toEqual([secondLayout]);
+
+    await storage.delete("default", "layout-1");
+    await storage.delete("unknown", "missing");
+    await storage.importLayouts();
+    await expect(storage.list("default")).resolves.toEqual([]);
+  });
+});

--- a/packages/suite-base/src/services/NullAnalytics.test.ts
+++ b/packages/suite-base/src/services/NullAnalytics.test.ts
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import NullAnalytics from "./NullAnalytics";
+
+describe("NullAnalytics", () => {
+  it("accepts events without producing side effects", () => {
+    expect(new NullAnalytics().logEvent("panel_opened", { source: "test" })).toBeUndefined();
+  });
+});

--- a/packages/suite-base/src/services/OrganizationService.test.ts
+++ b/packages/suite-base/src/services/OrganizationService.test.ts
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { OrganizationService } from "./OrganizationService";
+
+describe("OrganizationService", () => {
+  const apiClient = { get: jest.fn(), post: jest.fn(), request: jest.fn(), delete: jest.fn() };
+  const service = new OrganizationService(apiClient as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("maps nullable organization fields and performs organization mutations", async () => {
+    const organization = {
+      id: "org",
+      name: "Organization",
+      slug: "organization",
+      description: null,
+      avatar: null,
+      role: "owner",
+      createdAt: "created",
+      updatedAt: "updated",
+    };
+    apiClient.get.mockResolvedValue({ data: [organization] });
+    apiClient.post.mockResolvedValue({ data: organization });
+    apiClient.request.mockResolvedValue({ data: organization });
+    apiClient.delete.mockResolvedValue({ success: true });
+
+    await expect(service.getOrganizations()).resolves.toEqual([
+      { ...organization, description: undefined, avatar: undefined },
+    ]);
+    await expect(
+      service.createOrganization({ name: "Organization" } as never),
+    ).resolves.toMatchObject({
+      id: "org",
+    });
+    await expect(
+      service.updateOrganization("org", { name: "Updated" } as never),
+    ).resolves.toMatchObject({
+      id: "org",
+    });
+    await expect(service.deleteOrganization("org")).resolves.toBe(true);
+    expect(apiClient.request).toHaveBeenCalledWith("/api/orgs/org", {
+      method: "PATCH",
+      body: { name: "Updated" },
+    });
+  });
+
+  it("maps members and uses member endpoints", async () => {
+    const member = {
+      userId: "user",
+      email: "user@example.com",
+      name: null,
+      avatar: null,
+      role: "member",
+      joinedAt: "joined",
+    };
+    apiClient.get.mockResolvedValue({ data: [member] });
+    apiClient.post.mockResolvedValue({ data: member });
+    apiClient.request.mockResolvedValue({ data: member });
+    apiClient.delete.mockResolvedValue({ success: true });
+
+    await expect(service.getMembers("org")).resolves.toEqual([
+      { ...member, name: undefined, avatar: undefined },
+    ]);
+    await expect(service.addMember("org", { email: member.email } as never)).resolves.toMatchObject(
+      {
+        userId: "user",
+      },
+    );
+    await expect(
+      service.updateMemberRole("org", "user", { role: "admin" } as never),
+    ).resolves.toMatchObject({
+      role: "member",
+    });
+    await expect(service.removeMember("org", "user")).resolves.toBe(true);
+    expect(apiClient.request).toHaveBeenCalledWith("/api/orgs/org/members/user", {
+      method: "PATCH",
+      body: { role: "admin" },
+    });
+  });
+
+  it("passes through storage, API key, extension, and extension-setting responses", async () => {
+    const extension = { id: "extension", name: "Extension" };
+    apiClient.get
+      .mockResolvedValueOnce({ data: { usedBytes: 1 } })
+      .mockResolvedValueOnce({ data: [{ id: "key" }] })
+      .mockResolvedValueOnce({ data: [extension] })
+      .mockResolvedValueOnce({ data: extension })
+      .mockResolvedValueOnce({ data: [{ extensionId: "extension", enabled: true }] });
+    apiClient.post
+      .mockResolvedValueOnce({ data: { id: "key", token: "secret" } })
+      .mockResolvedValueOnce({ data: extension })
+      .mockResolvedValueOnce({ data: extension });
+    apiClient.request.mockResolvedValue({ data: { extensionId: "extension", enabled: false } });
+    apiClient.delete.mockResolvedValue({ success: true });
+
+    await expect(service.getStorageStats("org")).resolves.toEqual({ usedBytes: 1 });
+    await expect(service.getApiKeys("org")).resolves.toEqual([{ id: "key" }]);
+    await expect(service.createApiKey("org", "key")).resolves.toEqual({
+      id: "key",
+      token: "secret",
+    });
+    await expect(service.getExtensions("org", "approved" as never)).resolves.toEqual([extension]);
+    await expect(service.getExtension("org", "extension")).resolves.toEqual(extension);
+    await expect(service.uploadExtension("org", {} as never)).resolves.toEqual(extension);
+    await expect(service.reviewExtension("org", "extension", {} as never)).resolves.toEqual(
+      extension,
+    );
+    await expect(service.getExtensionSettings("org")).resolves.toEqual([
+      { extensionId: "extension", enabled: true },
+    ]);
+    await expect(service.updateExtensionSetting("org", "extension", {} as never)).resolves.toEqual({
+      extensionId: "extension",
+      enabled: false,
+    });
+    await expect(service.deleteApiKey("org", "key")).resolves.toBe(true);
+    await expect(service.deleteExtension("org", "extension")).resolves.toBe(true);
+    expect(apiClient.get).toHaveBeenCalledWith("/api/orgs/org/extensions?status=approved");
+    expect(apiClient.request).toHaveBeenCalledWith("/api/orgs/org/extension-settings/extension", {
+      method: "PUT",
+      body: {},
+    });
+  });
+});

--- a/packages/suite-base/src/services/RecordingService.test.ts
+++ b/packages/suite-base/src/services/RecordingService.test.ts
@@ -1,0 +1,109 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { RecordingService } from "./RecordingService";
+
+const recording = {
+  id: "recording-1",
+  name: "Drive",
+  size: 10,
+  format: "mcap",
+  status: "ready",
+} as never;
+
+describe("RecordingService", () => {
+  const apiClient = {
+    get: jest.fn(),
+    delete: jest.fn(),
+    uploadFileWithProgress: jest.fn(),
+    downloadBlob: jest.fn(),
+  };
+  const service = new RecordingService(apiClient as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("serializes recording filters and maps pagination", async () => {
+    apiClient.get.mockResolvedValue({ data: [recording], total: 21, page: 2, pageSize: 10 });
+
+    await expect(
+      service.getRecordings({
+        orgId: "org",
+        search: "drive",
+        deviceId: "device",
+        startTime: "start",
+        endTime: "end",
+        format: "mcap",
+        status: "ready",
+        page: 2,
+        pageSize: 10,
+      } as never),
+    ).resolves.toEqual({
+      recordings: [recording],
+      totalRecordings: 21,
+      page: 2,
+      pageSize: 10,
+      totalPages: 3,
+    });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/recordings?orgId=org&page=2&pageSize=10&search=drive&deviceId=device&startTime=start&endTime=end&format=mcap&status=ready",
+    );
+  });
+
+  it("uses the base endpoint without filters", async () => {
+    apiClient.get.mockResolvedValue({ data: [], total: 0, page: 1, pageSize: 10 });
+
+    await service.getRecordings();
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/recordings");
+  });
+
+  it("gets, deletes, uploads, and downloads recordings", async () => {
+    const file = new File(["contents"], "drive.mcap");
+    const blob = new Blob(["contents"]);
+    const onProgress = jest.fn();
+    apiClient.get
+      .mockResolvedValueOnce(recording)
+      .mockResolvedValueOnce({ url: "https://example.com/recording" });
+    apiClient.delete.mockResolvedValue(undefined);
+    apiClient.uploadFileWithProgress.mockImplementation(
+      async (
+        _endpoint: string,
+        _formData: FormData,
+        progress: (loaded: number, total: number) => void,
+      ) => {
+        progress(1, 3);
+        return recording;
+      },
+    );
+    apiClient.downloadBlob.mockResolvedValue(blob);
+
+    await expect(service.getRecording("recording-1")).resolves.toEqual(recording);
+    await expect(service.deleteRecording("recording-1")).resolves.toBe(true);
+    await expect(
+      service.uploadRecording(file, { deviceId: "device", orgId: "org" }, onProgress),
+    ).resolves.toEqual(recording);
+    await expect(service.downloadRecording("recording-1")).resolves.toBe(blob);
+    await expect(service.getDownloadUrl("recording-1")).resolves.toBe(
+      "https://example.com/recording",
+    );
+    expect(apiClient.uploadFileWithProgress).toHaveBeenCalledWith(
+      "/api/recordings/user-upload",
+      expect.any(FormData),
+      expect.any(Function),
+    );
+    expect(onProgress).toHaveBeenCalledWith({ loaded: 1, total: 3, percentage: 33 });
+  });
+
+  it("does not attach a progress adapter when no callback is supplied", async () => {
+    apiClient.uploadFileWithProgress.mockResolvedValue(recording);
+
+    await service.uploadRecording(new File(["contents"], "drive.mcap"));
+
+    expect(apiClient.uploadFileWithProgress).toHaveBeenCalledWith(
+      "/api/recordings/user-upload",
+      expect.any(FormData),
+      undefined,
+    );
+  });
+});

--- a/packages/suite-base/src/services/createAuthService.test.ts
+++ b/packages/suite-base/src/services/createAuthService.test.ts
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { ApiClient } from "./ApiClient";
+import { AuthService } from "./AuthService";
+import {
+  createAuthService,
+  createAuthServices,
+  createFloraServices,
+  DEFAULT_FLORA_SERVER_URL,
+  getFloraServerUrl,
+} from "./createAuthService";
+
+const tokens = {
+  getAccessToken: jest.fn(),
+  getRefreshToken: jest.fn(),
+  setTokens: jest.fn(),
+  clearTokens: jest.fn(),
+};
+
+describe("createAuthService", () => {
+  const originalServerUrl = process.env.FLORA_SERVER_URL;
+
+  afterEach(() => {
+    if (originalServerUrl == undefined) {
+      delete process.env.FLORA_SERVER_URL;
+    } else {
+      process.env.FLORA_SERVER_URL = originalServerUrl;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it("uses the public Flora server by default and honors the environment override", () => {
+    delete process.env.FLORA_SERVER_URL;
+    expect(getFloraServerUrl()).toBe(DEFAULT_FLORA_SERVER_URL);
+    process.env.FLORA_SERVER_URL = "https://self-hosted.example.com";
+    expect(getFloraServerUrl()).toBe("https://self-hosted.example.com");
+  });
+
+  it("creates matching authentication services with supplied token storage", () => {
+    const result = createAuthServices({ serverUrl: "https://example.com", tokenStorage: tokens });
+    expect(result.apiClient).toBeInstanceOf(ApiClient);
+    expect(result.authService).toBeInstanceOf(AuthService);
+    expect(createAuthService({ tokenStorage: tokens })).toBeInstanceOf(AuthService);
+  });
+
+  it("creates all API services and registers a session-expiry callback", () => {
+    const callback = jest.fn();
+    const callbackSpy = jest.spyOn(ApiClient.prototype, "setSessionExpiredCallback");
+    const services = createFloraServices({ tokenStorage: tokens, onSessionExpired: callback });
+
+    expect(services.authService).toBeInstanceOf(AuthService);
+    expect(services.apiClient).toBeInstanceOf(ApiClient);
+    expect(services.deviceService).toBeDefined();
+    expect(services.recordingService).toBeDefined();
+    expect(services.eventService).toBeDefined();
+    expect(services.organizationService).toBeDefined();
+    expect(callbackSpy).toHaveBeenCalledWith(callback);
+  });
+});

--- a/packages/suite-base/src/test/MockSendNotification.test.ts
+++ b/packages/suite-base/src/test/MockSendNotification.test.ts
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  mockSendNotification,
+  mockSetNotificationHandler,
+  setupMockSendNotification,
+} from "./MockSendNotification";
+
+describe("MockSendNotification", () => {
+  beforeEach(() => {
+    mockSendNotification.mockClear();
+    mockSetNotificationHandler();
+    setupMockSendNotification();
+  });
+
+  it("forwards notification arguments to the registered handler", () => {
+    const handler = jest.fn();
+    mockSetNotificationHandler(handler);
+
+    mockSendNotification("message", { detail: "value" } as never, "user" as never, "warn" as never);
+
+    expect(handler).toHaveBeenCalledWith("message", { detail: "value" }, "user", "warn");
+    (
+      mockSendNotification as unknown as { expectCalledDuringTest: () => void }
+    ).expectCalledDuringTest();
+  });
+
+  it("asserts and resets notification calls after a test", () => {
+    const assertCalled = (mockSendNotification as unknown as { expectCalledDuringTest: () => void })
+      .expectCalledDuringTest;
+
+    expect(assertCalled).toThrow("Expected sendNotification");
+    mockSendNotification("message", {} as never, "user" as never, "warn" as never);
+    expect(assertCalled).not.toThrow();
+    expect(mockSendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/packages/suite-base/src/types/isTypedArray.test.ts
+++ b/packages/suite-base/src/types/isTypedArray.test.ts
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { isTypedArray } from "./isTypedArray";
+
+describe("isTypedArray", () => {
+  it("identifies all typed-array views and rejects other values", () => {
+    expect(isTypedArray(new Uint8Array([1]))).toBe(true);
+    expect(isTypedArray(new Float64Array([1]))).toBe(true);
+    expect(isTypedArray(new DataView(new ArrayBuffer(1)))).toBe(false);
+    expect(isTypedArray([1])).toBe(false);
+    expect(isTypedArray(undefined)).toBe(false);
+  });
+});

--- a/packages/suite-base/src/util/BrowserHttpReader.test.ts
+++ b/packages/suite-base/src/util/BrowserHttpReader.test.ts
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import isDesktopApp from "./isDesktopApp";
+import FetchReader from "./FetchReader";
+
+import BrowserHttpReader from "./BrowserHttpReader";
+
+jest.mock("./isDesktopApp", () => jest.fn());
+jest.mock("./FetchReader", () => jest.fn());
+
+const fetchMock = jest.fn();
+global.fetch = fetchMock;
+
+const response = (options: { ok?: boolean; status?: number; headers?: Record<string, string> }) =>
+  ({
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    headers: new Headers(options.headers),
+  }) as Response;
+
+describe("BrowserHttpReader", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (isDesktopApp as jest.Mock).mockReturnValue(false);
+  });
+
+  it("opens a range-enabled remote file and returns its identity", async () => {
+    fetchMock.mockResolvedValueOnce(
+      response({
+        headers: { "accept-ranges": "bytes", "content-length": "42", etag: "version-1" },
+      }),
+    );
+
+    await expect(new BrowserHttpReader("https://example.com/file").open()).resolves.toEqual({
+      size: 42,
+      identifier: "version-1",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/file",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("reports request, range, and size failures with browser CORS guidance", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    await expect(new BrowserHttpReader("https://example.com/file").open()).rejects.toThrow(
+      "Make sure CORS is enabled.",
+    );
+
+    fetchMock.mockResolvedValueOnce(response({ ok: false, status: 403 }));
+    await expect(new BrowserHttpReader("https://example.com/file").open()).rejects.toThrow(
+      "Status code: 403",
+    );
+
+    fetchMock.mockResolvedValueOnce(response({ headers: { "content-length": "42" } }));
+    await expect(new BrowserHttpReader("https://example.com/file").open()).rejects.toThrow(
+      "Accept-Ranges: bytes",
+    );
+
+    fetchMock.mockResolvedValueOnce(response({ headers: { "accept-ranges": "bytes" } }));
+    await expect(new BrowserHttpReader("https://example.com/file").open()).rejects.toThrow(
+      "missing file size",
+    );
+  });
+
+  it("uses last-modified when an etag is not available and omits browser guidance on desktop", async () => {
+    (isDesktopApp as jest.Mock).mockReturnValue(true);
+    fetchMock.mockResolvedValueOnce(
+      response({
+        headers: {
+          "accept-ranges": "bytes",
+          "content-length": "1",
+          "last-modified": "yesterday",
+        },
+      }),
+    );
+    await expect(new BrowserHttpReader("https://example.com/file").open()).resolves.toEqual({
+      size: 1,
+      identifier: "yesterday",
+    });
+  });
+
+  it("creates and starts a range reader for byte requests", () => {
+    const read = jest.fn();
+    (FetchReader as jest.Mock).mockImplementation(() => ({ read }));
+
+    const reader = new BrowserHttpReader("https://example.com/file").fetch(10, 5);
+
+    expect(FetchReader).toHaveBeenCalledWith("https://example.com/file", {
+      headers: expect.objectContaining({}),
+    });
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(reader).toEqual({ read });
+  });
+});

--- a/packages/suite-base/src/util/FetchReader.test.ts
+++ b/packages/suite-base/src/util/FetchReader.test.ts
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import FetchReader from "./FetchReader";
+
+describe("FetchReader", () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock;
+  });
+
+  it("emits streamed data followed by end", async () => {
+    const read = jest
+      .fn()
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array([1, 2]) })
+      .mockResolvedValueOnce({ done: true });
+    fetchMock.mockResolvedValue({ ok: true, body: { getReader: () => ({ read }) } });
+    const reader = new FetchReader("https://example.test");
+    const data = jest.fn();
+    const end = jest.fn();
+    reader.on("data", data);
+    reader.on("end", end);
+
+    reader.read();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(data).toHaveBeenCalledWith(new Uint8Array([1, 2]));
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits a useful error for unsuccessful responses", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" });
+    const reader = new FetchReader("https://example.test");
+    const error = new Promise<Error>((resolve) => reader.on("error", resolve));
+
+    reader.read();
+
+    await expect(error).resolves.toEqual(
+      new Error("GET <$https://example.test> failed with status 404 (Not Found)"),
+    );
+  });
+
+  it.each([
+    ["rejected fetch", () => Promise.reject(new Error("offline")), "GET <https://example.test> failed: Error: offline"],
+    ["response without a body", () => Promise.resolve({ ok: true, body: undefined }), "GET <https://example.test> succeeded, but returned no data"],
+    [
+      "reader initialization failure",
+      () => Promise.resolve({ ok: true, body: { getReader: () => { throw new Error("locked"); } } }),
+      "GET <https://example.test> succeeded, but failed to stream",
+    ],
+  ])("emits an error for %s", async (_name, response, message) => {
+    fetchMock.mockImplementation(response);
+    const reader = new FetchReader("https://example.test");
+    const error = new Promise<Error>((resolve) => reader.on("error", resolve));
+
+    reader.read();
+
+    await expect(error).resolves.toEqual(new Error(message));
+  });
+
+  it("emits read errors and turns aborted read errors into end", async () => {
+    const read = jest.fn().mockRejectedValue(new Error("stream failed"));
+    fetchMock.mockResolvedValue({ ok: true, body: { getReader: () => ({ read }) } });
+    const reader = new FetchReader("https://example.test");
+    const error = new Promise<Error>((resolve) => reader.on("error", resolve));
+
+    reader.read();
+    await expect(error).resolves.toEqual(new Error("stream failed"));
+  });
+
+  it("wraps non-Error read rejections", async () => {
+    const read = jest.fn().mockRejectedValue("stream failed");
+    fetchMock.mockResolvedValue({ ok: true, body: { getReader: () => ({ read }) } });
+    const reader = new FetchReader("https://example.test");
+    const error = new Promise<Error>((resolve) => reader.on("error", resolve));
+
+    reader.read();
+
+    await expect(error).resolves.toEqual(new Error("stream failed"));
+  });
+
+  it("emits end when an in-flight read fails after destruction", async () => {
+    let rejectRead!: (error: Error) => void;
+    const read = jest.fn(
+      () =>
+        new Promise((_, reject) => {
+          rejectRead = reject;
+        }),
+    );
+    fetchMock.mockResolvedValue({ ok: true, body: { getReader: () => ({ read }) } });
+    const reader = new FetchReader("https://example.test");
+    const end = new Promise<void>((resolve) => reader.on("end", resolve));
+
+    reader.read();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    reader.destroy();
+    rejectRead(new Error("aborted"));
+
+    await end;
+  });
+
+  it("aborts the underlying request when destroyed", () => {
+    fetchMock.mockResolvedValue({ ok: true, body: { getReader: jest.fn() } });
+    const reader = new FetchReader("https://example.test");
+
+    reader.destroy();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+});

--- a/packages/suite-base/src/util/setImmediate.test.ts
+++ b/packages/suite-base/src/util/setImmediate.test.ts
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import setImmediate from "./setImmediate";
+
+describe("setImmediate", () => {
+  it("schedules the callback on a microtask with all arguments", async () => {
+    const callback = jest.fn();
+    expect(setImmediate(callback, "value", 2)).toBeUndefined();
+    expect(callback).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(callback).toHaveBeenCalledWith("value", 2);
+  });
+});

--- a/packages/suite-base/src/util/showOpenFilePicker.test.tsx
+++ b/packages/suite-base/src/util/showOpenFilePicker.test.tsx
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import showOpenFilePicker from "./showOpenFilePicker";
+
+describe("showOpenFilePicker", () => {
+  afterEach(() => {
+    delete (window as unknown as { showOpenFilePicker?: unknown }).showOpenFilePicker;
+    jest.restoreAllMocks();
+  });
+
+  it("uses the native picker when available", async () => {
+    const handles = [{ name: "file" }] as never;
+    const picker = jest.fn().mockResolvedValue(handles);
+    (window as unknown as { showOpenFilePicker: typeof picker }).showOpenFilePicker = picker;
+
+    await expect(showOpenFilePicker({ multiple: true })).resolves.toBe(handles);
+    expect(picker).toHaveBeenCalledWith({ multiple: true });
+  });
+
+  it("converts native picker cancellation to an empty selection", async () => {
+    const picker = jest.fn().mockRejectedValue({ name: "AbortError" });
+    (window as unknown as { showOpenFilePicker: typeof picker }).showOpenFilePicker = picker;
+
+    await expect(showOpenFilePicker()).resolves.toEqual([]);
+  });
+
+  it("uses a configured input fallback when the native picker is unavailable", async () => {
+    const input = document.createElement("input");
+    const file = new File(["content"], "data.csv", { type: "text/csv" });
+    Object.defineProperty(input, "files", { value: [file] });
+    jest.spyOn(input, "click").mockImplementation(() => input.onchange?.(new Event("change")));
+    jest.spyOn(document, "createElement").mockReturnValue(input);
+
+    const handles = await showOpenFilePicker({
+      multiple: true,
+      types: [{ accept: { "text/csv": [".csv"], "application/json": ".json" } }],
+    });
+
+    expect(input.multiple).toBe(true);
+    expect(input.accept).toBe(".csv,.json");
+    expect(handles).toHaveLength(1);
+    expect(handles[0]!.name).toBe("data.csv");
+    await expect(handles[0]!.getFile()).resolves.toBe(file);
+  });
+
+  it("propagates native picker failures other than cancellation", async () => {
+    const picker = jest.fn().mockRejectedValue(new Error("not allowed"));
+    (window as unknown as { showOpenFilePicker: typeof picker }).showOpenFilePicker = picker;
+    await expect(showOpenFilePicker()).rejects.toThrow("not allowed");
+  });
+});

--- a/packages/suite-desktop/src/main/rosPackageResources.test.ts
+++ b/packages/suite-desktop/src/main/rosPackageResources.test.ts
@@ -2,58 +2,64 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import fs from "fs";
+import os from "os";
 import path from "path";
 
-import { findRosPackage, rosPackageNameAtPath } from "./rosPackageResources";
+import {
+  findRosPackage,
+  findRosPackageInRoot,
+  rosPackageNameAtPath,
+} from "./rosPackageResources";
 
-const FIXTURES_ROOT = path.join(__dirname, "./fixtures");
-const PACKAGES_ROOT = path.join(FIXTURES_ROOT, "./packages");
+describe("ROS package resource lookup", () => {
+  let root: string;
+  const originalRosPackagePath = process.env.ROS_PACKAGE_PATH;
 
-describe("rosPackageResources", () => {
-  describe("rosPackageNameAtPath", () => {
-    it("should read package name from package.xml file at path", async () => {
-      const name = await rosPackageNameAtPath(path.join(PACKAGES_ROOT, "./foo"));
-      expect(name).toEqual("foo");
-    });
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "flora-ros-package-test-"));
+    delete process.env.ROS_PACKAGE_PATH;
   });
 
-  describe("findRosPackage", () => {
-    it("should find package within rosPackagePath", async () => {
-      const packagePath = await findRosPackage("foo", { rosPackagePath: PACKAGES_ROOT });
-      expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
-    });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    if (originalRosPackagePath == undefined) {
+      delete process.env.ROS_PACKAGE_PATH;
+    } else {
+      process.env.ROS_PACKAGE_PATH = originalRosPackagePath;
+    }
+  });
 
-    it("should find package within multiple rosPackagePaths", async () => {
-      const packagePath = await findRosPackage("foo", {
-        rosPackagePath: `${FIXTURES_ROOT}${path.delimiter}${PACKAGES_ROOT}`,
-      });
-      expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
+  it("reads a package name and finds nested ROS packages", async () => {
+    const nested = path.join(root, "workspace", "share", "demo");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, "package.xml"), "<package><name>demo_pkg</name></package>");
 
-      // Since findRosPackageInRoot searches recursively, the package is found in the first path
-      // No console.error should be called
-    });
+    await expect(rosPackageNameAtPath(nested)).resolves.toBe("demo_pkg");
+    await expect(findRosPackageInRoot("demo_pkg", root)).resolves.toBe(nested);
+    await expect(findRosPackageInRoot("missing", root)).resolves.toBeUndefined();
+  });
 
-    it("should find package within process.env.ROS_PACKAGE_PATH", async () => {
-      process.env.ROS_PACKAGE_PATH = `${FIXTURES_ROOT}${path.delimiter}${PACKAGES_ROOT}`;
-      try {
-        const packagePath = await findRosPackage("foo");
-        expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
-      } finally {
-        process.env.ROS_PACKAGE_PATH = undefined;
-      }
+  it("uses configured paths before ROS_PACKAGE_PATH", async () => {
+    const configured = path.join(root, "configured");
+    const environment = path.join(root, "environment");
+    const configuredPackage = path.join(configured, "target");
+    const environmentPackage = path.join(environment, "target");
+    fs.mkdirSync(configuredPackage, { recursive: true });
+    fs.mkdirSync(environmentPackage, { recursive: true });
+    fs.writeFileSync(
+      path.join(configuredPackage, "package.xml"),
+      "<package><name>target</name></package>",
+    );
+    fs.writeFileSync(
+      path.join(environmentPackage, "package.xml"),
+      "<package><name>target</name></package>",
+    );
+    process.env.ROS_PACKAGE_PATH = environment;
 
-      // Since findRosPackageInRoot searches recursively, the package is found in the first path
-      // No console.error should be called
-    });
-
-    it("should find packages recursively within rosPackagePath", async () => {
-      const packagePath = await findRosPackage("nested-child", {
-        rosPackagePath: PACKAGES_ROOT,
-      });
-      expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "nested", "child"));
-
-      // The package is found through recursive search
-      // No console.error should be called
-    });
+    await expect(findRosPackage("target", { rosPackagePath: configured })).resolves.toBe(
+      configuredPackage,
+    );
+    await expect(findRosPackage("target")).resolves.toBe(environmentPackage);
   });
 });

--- a/packages/suite-desktop/src/main/settings.test.ts
+++ b/packages/suite-desktop/src/main/settings.test.ts
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import {
+  DATASTORES_DIR_NAME,
+  SETTINGS_DATASTORE_NAME,
+  SETTINGS_JSON_DATASTORE_KEY,
+} from "../common/storage";
+import { getAppSetting, setAppSetting } from "./settings";
+
+describe("app settings", () => {
+  let userDataDir: string;
+
+  beforeEach(() => {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "flora-settings-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it("writes and reads a setting from the override user-data directory", () => {
+    setAppSetting("theme" as never, "dark", { overrideUserDataDir: userDataDir });
+
+    expect(getAppSetting("theme" as never, { overrideUserDataDir: userDataDir })).toBe("dark");
+  });
+
+  it("returns undefined for missing and malformed settings files", () => {
+    expect(getAppSetting("theme" as never, { overrideUserDataDir: userDataDir })).toBeUndefined();
+
+    const settingsPath = path.join(
+      userDataDir,
+      DATASTORES_DIR_NAME,
+      SETTINGS_DATASTORE_NAME,
+      SETTINGS_JSON_DATASTORE_KEY,
+    );
+    fs.writeFileSync(settingsPath, "not json");
+    expect(getAppSetting("theme" as never, { overrideUserDataDir: userDataDir })).toBeUndefined();
+  });
+});

--- a/packages/suite-desktop/src/quicklook/getIndexedMcapInfo.test.ts
+++ b/packages/suite-desktop/src/quicklook/getIndexedMcapInfo.test.ts
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { McapIndexedReader } from "@mcap/core";
+
+import getIndexedMcapInfo from "./getIndexedMcapInfo";
+
+describe("getIndexedMcapInfo", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("aggregates indexed channels, schemas, counts, chunks, and attachments", async () => {
+    jest.spyOn(McapIndexedReader, "Initialize").mockResolvedValue({
+      channelsById: new Map([
+        [1, { id: 1, topic: "/topic", schemaId: 1 }],
+        [2, { id: 2, topic: "/topic", schemaId: 2 }],
+      ]),
+      schemasById: new Map([
+        [1, { name: "First" }],
+        [2, { name: "Second" }],
+      ]),
+      statistics: {
+        messageCount: 3n,
+        channelMessageCounts: new Map([
+          [1, 1n],
+          [2, 2n],
+        ]),
+      },
+      chunkIndexes: [{ compression: "zstd", messageStartTime: 10n, messageEndTime: 20n }],
+      attachmentIndexes: [{}],
+    } as never);
+
+    const result = await getIndexedMcapInfo(new Blob(["mcap"]), {} as never);
+
+    expect(result).toMatchObject({
+      fileType: "MCAP v0, indexed",
+      numChunks: 1,
+      numAttachments: 1,
+      totalMessages: 3n,
+      compressionTypes: new Set(["zstd"]),
+    });
+    expect(result.topics).toEqual([
+      { topic: "/topic", schemaName: "(multiple)", numMessages: 3n, numConnections: 2 },
+    ]);
+  });
+
+  it("rejects indexed summaries with channels referencing missing schemas", async () => {
+    jest.spyOn(McapIndexedReader, "Initialize").mockResolvedValue({
+      channelsById: new Map([[1, { id: 1, topic: "/topic", schemaId: 1 }]]),
+      schemasById: new Map(),
+      statistics: { messageCount: 1n, channelMessageCounts: new Map() },
+      chunkIndexes: [],
+      attachmentIndexes: [],
+    } as never);
+
+    await expect(getIndexedMcapInfo(new Blob(), {} as never)).rejects.toThrow(
+      "MCAP summary does not contain channels or schemas",
+    );
+  });
+});

--- a/packages/suite-desktop/src/quicklook/getMcapInfo.test.ts
+++ b/packages/suite-desktop/src/quicklook/getMcapInfo.test.ts
@@ -10,6 +10,12 @@ import { TempBuffer } from "@lichtblick/mcap-support";
 import { getMcapInfo } from "./getMcapInfo";
 
 describe("getMcapInfo", () => {
+  it("rejects files without the MCAP magic prefix", async () => {
+    await expect(getMcapInfo(new Blob(["not an mcap file"]) as globalThis.Blob)).rejects.toThrow(
+      "Not a valid MCAP file",
+    );
+  });
+
   it("returns correct values for an empty MCAP file", async () => {
     const tempBuffer = new TempBuffer();
 

--- a/packages/suite-desktop/src/quicklook/getStreamedMcapInfo.test.ts
+++ b/packages/suite-desktop/src/quicklook/getStreamedMcapInfo.test.ts
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import getStreamedMcapInfo, { processMcapRecord } from "./getStreamedMcapInfo";
+
+describe("processMcapRecord", () => {
+  it("collects streamed MCAP topic, schema, message, chunk, and attachment information", () => {
+    const info = {
+      totalMessages: 0n,
+      numChunks: 0,
+      numAttachments: 0,
+      startTime: undefined,
+      endTime: undefined,
+      compressionTypes: new Set<string>(),
+      topicInfosByTopic: new Map(),
+      topicNamesByChannelId: new Map(),
+      schemaNamesById: new Map(),
+    };
+
+    processMcapRecord(info as never, { type: "Chunk", compression: "zstd" } as never);
+    processMcapRecord(info as never, { type: "Attachment" } as never);
+    processMcapRecord(info as never, { type: "Schema", id: 1, name: "First" } as never);
+    processMcapRecord(
+      info as never,
+      { type: "Channel", id: 10, topic: "/topic", schemaId: 1 } as never,
+    );
+    processMcapRecord(info as never, { type: "Message", channelId: 10, logTime: 20n } as never);
+    processMcapRecord(info as never, { type: "Schema", id: 2, name: "Second" } as never);
+    processMcapRecord(
+      info as never,
+      { type: "Channel", id: 11, topic: "/topic", schemaId: 2 } as never,
+    );
+    processMcapRecord(
+      info as never,
+      { type: "Channel", id: 12, topic: "/unknown", schemaId: 99 } as never,
+    );
+    processMcapRecord(
+      info as never,
+      { type: "Channel", id: 13, topic: "/unknown", schemaId: 99 } as never,
+    );
+    processMcapRecord(
+      info as never,
+      { type: "Channel", id: 11, topic: "/topic", schemaId: 2 } as never,
+    );
+    processMcapRecord(info as never, { type: "Message", channelId: 99, logTime: 30n } as never);
+    processMcapRecord(info as never, { type: "Metadata" } as never);
+
+    expect(info.numChunks).toBe(1);
+    expect(info.numAttachments).toBe(1);
+    expect(info.compressionTypes).toEqual(new Set(["zstd"]));
+    expect(info.totalMessages).toBe(2n);
+    expect(info.topicInfosByTopic.get("/topic")).toMatchObject({
+      schemaName: "(multiple)",
+      numMessages: 1n,
+      numConnections: 2,
+    });
+    expect(info.topicInfosByTopic.get("/unknown")).toMatchObject({
+      schemaName: "(unknown)",
+      numConnections: 2,
+    });
+  });
+
+  it("streams records from a reader and reports progress", async () => {
+    const records = [
+      { type: "Schema", id: 1, name: "Message" },
+      { type: "Channel", id: 1, topic: "/z", schemaId: 1 },
+      { type: "Channel", id: 2, topic: "/a", schemaId: 1 },
+      { type: "Message", channelId: 1, logTime: 10n },
+    ];
+    const reader = {
+      done: () => records.length === 0,
+      bytesRemaining: () => 0,
+      append: jest.fn(),
+      nextRecord: () => records.shift(),
+    };
+    const progress = jest.fn();
+
+    const result = await getStreamedMcapInfo(
+      new Blob(["mcap data"]),
+      reader,
+      processMcapRecord as never,
+      "MCAP streamed",
+      progress,
+    );
+
+    expect(reader.append).toHaveBeenCalledTimes(1);
+    expect(progress).toHaveBeenLastCalledWith(1);
+    expect(result).toMatchObject({ fileType: "MCAP streamed", totalMessages: 1n });
+    expect(result.topics.map((topic) => topic.topic)).toEqual(["/a", "/z"]);
+  });
+});

--- a/packages/suite-desktop/src/quicklook/getStreamedMcapInfo.test.ts
+++ b/packages/suite-desktop/src/quicklook/getStreamedMcapInfo.test.ts
@@ -75,9 +75,13 @@ describe("processMcapRecord", () => {
       nextRecord: () => records.shift(),
     };
     const progress = jest.fn();
+    const file = {
+      size: 9,
+      slice: jest.fn().mockReturnValue({ arrayBuffer: async () => new ArrayBuffer(9) }),
+    } as unknown as Blob;
 
     const result = await getStreamedMcapInfo(
-      new Blob(["mcap data"]),
+      file,
       reader,
       processMcapRecord as never,
       "MCAP streamed",
@@ -85,6 +89,7 @@ describe("processMcapRecord", () => {
     );
 
     expect(reader.append).toHaveBeenCalledTimes(1);
+    expect(file.slice).toHaveBeenCalledWith(0, 1024 * 1024);
     expect(progress).toHaveBeenLastCalledWith(1);
     expect(result).toMatchObject({ fileType: "MCAP streamed", totalMessages: 1n });
     expect(result.topics.map((topic) => topic.topic)).toEqual(["/a", "/z"]);

--- a/packages/theme/jest.config.json
+++ b/packages/theme/jest.config.json
@@ -1,0 +1,9 @@
+{
+  "testMatch": ["<rootDir>/src/**/*.test.ts(x)?"],
+  "transform": {
+    "\\.[jt]sx?$": ["babel-jest", { "rootMode": "upward" }]
+  },
+  "testEnvironment": "jsdom",
+  "setupFiles": ["<rootDir>/src/test/setup.ts"],
+  "haste": { "forceNodeFilesystemAPI": true }
+}

--- a/packages/theme/src/createMuiTheme.test.ts
+++ b/packages/theme/src/createMuiTheme.test.ts
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as componentOverrides from "./components";
+import { createMuiTheme } from "./createMuiTheme";
+
+describe("createMuiTheme", () => {
+  it.each(["light", "dark"] as const)("creates the %s theme with every component override", (name) => {
+    const theme = createMuiTheme(name);
+
+    expect(theme.name).toBe(name);
+    expect(Object.keys(theme.components)).toEqual(expect.arrayContaining(Object.keys(componentOverrides)));
+  });
+
+  it("evaluates every component style override with a complete theme context", () => {
+    const theme = createMuiTheme("light");
+    const results: unknown[] = [];
+
+    for (const override of Object.values(componentOverrides) as Array<Record<string, unknown>>) {
+      const styleOverrides = override.styleOverrides as Record<string, unknown> | undefined;
+      if (styleOverrides == undefined) {
+        continue;
+      }
+      for (const style of Object.values(styleOverrides)) {
+        if (typeof style === "function") {
+          results.push(style({ theme, ownerState: {} }));
+        }
+      }
+    }
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => typeof result === "object")).toBe(true);
+  });
+});

--- a/packages/theme/src/test/setup.ts
+++ b/packages/theme/src/test/setup.ts
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import React from "react";
+
+Object.assign(globalThis, { React });


### PR DESCRIPTION
## Summary

- add unit coverage for shared packages and suite-base services, utilities, and components
- add package Jest configuration needed to run the new test suites

## Validation

- `yarn test:coverage` (331 suites, 2,248 tests, 38 snapshots)
- targeted Jest suites for newly added data-source and UI coverage