### PR TITLE
feat: support Flora extension data loaders

### DIFF
--- a/packages/suite-base/src/components/PlayerManager.tsx
+++ b/packages/suite-base/src/components/PlayerManager.tsx
@@ -34,6 +34,7 @@ import {
 } from "@lichtblick/suite-base/context/CurrentLayoutContext";
 import { ExtensionCatalogContext } from "@lichtblick/suite-base/context/ExtensionCatalogContext";
 import { usePerformance } from "@lichtblick/suite-base/context/PerformanceContext";
+import { WasmDataLoaderDataSourceFactory } from "@lichtblick/suite-base/dataSources/WasmDataLoaderDataSourceFactory";
 import PlayerSelectionContext, {
   DataSourceArgs,
   IDataSourceFactory,
@@ -106,6 +107,30 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   // Update the alias functions when they change. We do not need to re-render the player manager
   // since nothing in the local state has changed.
   const extensionCatalogContext = useContext(ExtensionCatalogContext);
+  const [dataLoaderSources, setDataLoaderSources] = useState<readonly IDataSourceFactory[]>(() =>
+    (extensionCatalogContext?.getState().installedDataLoaders ?? []).map(
+      (registration) => new WasmDataLoaderDataSourceFactory(registration),
+    ),
+  );
+  useEffect(() => {
+    const updateDataLoaders = () => {
+      setDataLoaderSources(
+        (extensionCatalogContext?.getState().installedDataLoaders ?? []).map(
+          (registration) => new WasmDataLoaderDataSourceFactory(registration),
+        ),
+      );
+    };
+    updateDataLoaders();
+    return extensionCatalogContext?.subscribe((state, previousState) => {
+      if (state.installedDataLoaders !== previousState.installedDataLoaders) {
+        updateDataLoaders();
+      }
+    });
+  }, [extensionCatalogContext]);
+  const availablePlayerSources = useMemo(
+    () => [...playerSources, ...dataLoaderSources],
+    [dataLoaderSources, playerSources],
+  );
   useEffect(() => {
     // Stable empty alias functions if we don't have any
     const emptyAliasFunctions: Immutable<TopicAliasFunctions> = [];
@@ -150,7 +175,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
     async (sourceId: string, args?: DataSourceArgs) => {
       log.debug(`Select Source: ${sourceId}`);
 
-      const foundSource = playerSources.find(
+      const foundSource = availablePlayerSources.find(
         (source) => source.id === sourceId || source.legacyIds?.includes(sourceId),
       );
       if (!foundSource) {
@@ -294,7 +319,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
         enqueueSnackbar((error as Error).message, { variant: "error" });
       }
     },
-    [playerSources, metricsCollector, enqueueSnackbar, isMounted, addRecent],
+    [availablePlayerSources, metricsCollector, enqueueSnackbar, isMounted, addRecent],
   );
 
   // Select a recent entry by id
@@ -316,7 +341,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
     selectSource,
     selectRecent,
     selectedSource,
-    availableSources: playerSources,
+    availableSources: availablePlayerSources,
     recentSources,
     selectedRecentId,
     recentSourcesLoading,

--- a/packages/suite-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/suite-base/src/context/ExtensionCatalogContext.ts
@@ -7,6 +7,7 @@ import { StoreApi, useStore } from "zustand";
 
 import { useGuaranteedContext } from "@lichtblick/hooks";
 import {
+  Experimental,
   ExtensionPanelRegistration,
   Immutable,
   PanelSettings,
@@ -46,6 +47,7 @@ export type ExtensionCatalog = Immutable<{
   installedExtensions: undefined | ExtensionInfo[];
   installedPanels: undefined | Record<string, RegisteredPanel>;
   installedMessageConverters: undefined | Omit<MessageConverter, "panelSettings">[];
+  installedDataLoaders: undefined | RegisteredDataLoader[];
   installedTopicAliasFunctions: undefined | TopicAliasFunctions;
   panelSettings: undefined | ExtensionSettings;
 }>;
@@ -55,9 +57,15 @@ export type MessageConverter = RegisterMessageConverterArgs<unknown> & {
   extensionId?: string;
 };
 
+export type RegisteredDataLoader = Experimental.DataLoaderRegistration & {
+  extensionId: string;
+  extensionNamespace?: ExtensionNamespace;
+};
+
 export type ContributionPoints = {
   panels: Record<string, RegisteredPanel>;
   messageConverters: MessageConverter[];
+  dataLoaders: RegisteredDataLoader[];
   topicAliasFunctions: TopicAliasFunctions;
   panelSettings: ExtensionSettings;
 };

--- a/packages/suite-base/src/dataSources/WasmDataLoaderDataSourceFactory.ts
+++ b/packages/suite-base/src/dataSources/WasmDataLoaderDataSourceFactory.ts
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import {
+  DataSourceFactoryInitializeArgs,
+  IDataSourceFactory,
+} from "@lichtblick/suite-base/context/PlayerSelectionContext";
+import { RegisteredDataLoader } from "@lichtblick/suite-base/context/ExtensionCatalogContext";
+import { IterablePlayer } from "@lichtblick/suite-base/players/IterablePlayer";
+import { WasmDataLoaderIterableSource } from "@lichtblick/suite-base/players/IterablePlayer/WasmDataLoader/WasmDataLoaderIterableSource";
+import { Player } from "@lichtblick/suite-base/players/types";
+import { mergeMultipleFileNames } from "@lichtblick/suite-base/util/mergeMultipleFileName";
+
+export class WasmDataLoaderDataSourceFactory implements IDataSourceFactory {
+  readonly #registration: RegisteredDataLoader;
+
+  public constructor(registration: RegisteredDataLoader) {
+    this.#registration = registration;
+  }
+
+  public get id(): string {
+    return `extension-data-loader:${this.#registration.extensionId}:${this.#registration.supportedFileType}`;
+  }
+
+  public type: IDataSourceFactory["type"] = "file";
+  public get displayName(): string {
+    return `${this.#registration.extensionId} (${this.#registration.supportedFileType})`;
+  }
+  public iconName: IDataSourceFactory["iconName"] = "OpenFile";
+  public get supportedFileTypes(): string[] {
+    return [this.#registration.supportedFileType];
+  }
+  public get supportsMultiFile(): boolean {
+    return this.#registration.supportsMultiFile ?? false;
+  }
+
+  public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
+    const files = [...(args.files ?? []), ...(args.file ? [args.file] : [])];
+    if (files.length === 0 || (!this.supportsMultiFile && files.length !== 1)) {
+      return;
+    }
+    return new IterablePlayer({
+      metricsCollector: args.metricsCollector,
+      source: new WasmDataLoaderIterableSource({ wasmUrl: this.#registration.wasmUrl, files }),
+      name: mergeMultipleFileNames(files.map((file) => file.name)),
+      sourceId: this.id,
+    });
+  }
+}

--- a/packages/suite-base/src/players/IterablePlayer/WasmDataLoader/WasmDataLoaderIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/WasmDataLoader/WasmDataLoaderIterableSource.ts
@@ -246,7 +246,9 @@ export class WasmDataLoaderIterableSource implements IIterableSource {
       },
     };
     const wasm = decodeDataUrl(this.#wasmUrl);
-    const module = await WebAssembly.compile(wasm);
+    const wasmBuffer = new ArrayBuffer(wasm.byteLength);
+    new Uint8Array(wasmBuffer).set(wasm);
+    const module = await WebAssembly.compile(wasmBuffer);
     const wasmInstance = await WebAssembly.instantiate(module, imports);
     instance = { exports: wasmInstance.exports as LoaderInstance["exports"], paths, readers };
     this.#instance = instance;

--- a/packages/suite-base/src/players/IterablePlayer/WasmDataLoader/WasmDataLoaderIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/WasmDataLoader/WasmDataLoaderIterableSource.ts
@@ -1,0 +1,469 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { fromNanoSec, toNanoSec } from "@lichtblick/rostime";
+import { Immutable, MessageEvent } from "@lichtblick/suite";
+import { ParsedChannel, parseChannel } from "@lichtblick/mcap-support";
+import { PlayerProblem, Topic, TopicStats } from "@lichtblick/suite-base/players/types";
+import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
+
+import {
+  GetBackfillMessagesArgs,
+  IIterableSource,
+  Initialization,
+  IteratorResult,
+  MessageIteratorArgs,
+} from "../IIterableSource";
+
+type LoaderChannel = {
+  id: number;
+  schemaId?: number;
+  topicName: string;
+  messageEncoding: string;
+  messageCount?: bigint;
+};
+
+type LoaderSchema = { id: number; name: string; encoding: string; data: Uint8Array };
+
+type LoaderMessage = {
+  channelId: number;
+  logTime: bigint;
+  publishTime: bigint;
+  data: Uint8Array;
+};
+
+type LoaderInstance = {
+  exports: Record<string, unknown> & { memory: WebAssembly.Memory };
+  paths: string[];
+  readers: Map<number, { bytes: Uint8Array; position: number }>;
+};
+
+const READER_MODULE = "foxglove:loader/reader@0.1.0";
+const EXPORT_MODULE = "[export]foxglove:loader/loader@0.1.0";
+const LOADER_EXPORT = "foxglove:loader/loader@0.1.0";
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
+function decodeDataUrl(url: string): Uint8Array {
+  const match = /^data:application\/wasm;base64,([a-zA-Z0-9+/=]+)$/.exec(url);
+  if (!match) {
+    throw new Error("Data loader does not contain an inline WebAssembly module");
+  }
+  const binary = atob(match[1]!);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function memory(instance: LoaderInstance): Uint8Array {
+  return new Uint8Array(instance.exports.memory.buffer);
+}
+
+function exportedFunction(instance: LoaderInstance, name: string): (...args: unknown[]) => number {
+  const value = instance.exports[name];
+  if (typeof value !== "function") {
+    throw new Error(`Data loader is missing required export: ${name}`);
+  }
+  return value as (...args: unknown[]) => number;
+}
+
+function view(instance: LoaderInstance): DataView {
+  return new DataView(instance.exports.memory.buffer);
+}
+
+function readString(instance: LoaderInstance, pointer: number, length: number): string {
+  return textDecoder.decode(memory(instance).subarray(pointer, pointer + length));
+}
+
+function allocate(instance: LoaderInstance, size: number, alignment = 1): number {
+  return exportedFunction(instance, "cabi_realloc")(0, 0, alignment, size);
+}
+
+function readU64(data: DataView, offset: number): bigint {
+  return data.getBigUint64(offset, true);
+}
+
+function loaderError(instance: LoaderInstance, pointer: number): string {
+  const data = view(instance);
+  return readString(
+    instance,
+    data.getUint32(pointer + 8, true),
+    data.getUint32(pointer + 12, true),
+  );
+}
+
+function decodeChannels(
+  instance: LoaderInstance,
+  pointer: number,
+  length: number,
+): LoaderChannel[] {
+  const data = view(instance);
+  const channels: LoaderChannel[] = [];
+  // WIT canonical ABI layout of loader.channel is 40 bytes.
+  for (let index = 0; index < length; index++) {
+    const offset = pointer + index * 40;
+    const schemaTag = data.getUint8(offset + 2);
+    const countTag = data.getUint32(offset + 24, true);
+    channels.push({
+      id: data.getUint16(offset, true),
+      schemaId: schemaTag === 1 ? data.getUint16(offset + 4, true) : undefined,
+      topicName: readString(
+        instance,
+        data.getUint32(offset + 8, true),
+        data.getUint32(offset + 12, true),
+      ),
+      messageEncoding: readString(
+        instance,
+        data.getUint32(offset + 16, true),
+        data.getUint32(offset + 20, true),
+      ),
+      messageCount: countTag === 1 ? readU64(data, offset + 32) : undefined,
+    });
+  }
+  return channels;
+}
+
+function decodeSchemas(instance: LoaderInstance, pointer: number, length: number): LoaderSchema[] {
+  const data = view(instance);
+  const schemas: LoaderSchema[] = [];
+  // WIT canonical ABI layout of loader.schema is 28 bytes.
+  for (let index = 0; index < length; index++) {
+    const offset = pointer + index * 28;
+    const bytes = memory(instance).slice(
+      data.getUint32(offset + 20, true),
+      data.getUint32(offset + 20, true) + data.getUint32(offset + 24, true),
+    );
+    schemas.push({
+      id: data.getUint16(offset, true),
+      name: readString(
+        instance,
+        data.getUint32(offset + 4, true),
+        data.getUint32(offset + 8, true),
+      ),
+      encoding: readString(
+        instance,
+        data.getUint32(offset + 12, true),
+        data.getUint32(offset + 16, true),
+      ),
+      data: bytes,
+    });
+  }
+  return schemas;
+}
+
+function decodeMessage(instance: LoaderInstance, pointer: number): LoaderMessage {
+  const data = view(instance);
+  return {
+    channelId: data.getUint16(pointer, true),
+    logTime: readU64(data, pointer + 8),
+    publishTime: readU64(data, pointer + 16),
+    data: memory(instance).slice(
+      data.getUint32(pointer + 24, true),
+      data.getUint32(pointer + 24, true) + data.getUint32(pointer + 28, true),
+    ),
+  };
+}
+
+/**
+ * Browser host for the `foxglove:loader@0.1.0` canonical ABI used by extension data loaders.
+ * Files are materialized before instantiation so its synchronous reader imports remain safe in a
+ * browser and cannot access anything other than the files chosen by the user.
+ */
+export class WasmDataLoaderIterableSource implements IIterableSource {
+  readonly #wasmUrl: string;
+  readonly #files: readonly File[];
+  #instance: LoaderInstance | undefined;
+  #loader: number | undefined;
+  #channels = new Map<number, LoaderChannel>();
+  #schemas = new Map<number, LoaderSchema>();
+  #parsedChannels = new Map<number, ParsedChannel>();
+
+  public constructor(args: { wasmUrl: string; files: readonly File[] }) {
+    this.#wasmUrl = args.wasmUrl;
+    this.#files = args.files;
+  }
+
+  public async initialize(): Promise<Initialization> {
+    const fileBytes = await Promise.all(
+      this.#files.map(async (file) => new Uint8Array(await file.arrayBuffer())),
+    );
+    const readers = new Map<number, { bytes: Uint8Array; position: number }>();
+    const paths = this.#files.map((_file, index) => `flora-file-${index}`);
+    let nextReader = 1;
+    let instance: LoaderInstance | undefined;
+    const getInstance = (): LoaderInstance => {
+      if (!instance) {
+        throw new Error("WebAssembly data loader was called before initialization");
+      }
+      return instance;
+    };
+    const imports: WebAssembly.Imports = {
+      [READER_MODULE]: {
+        "[resource-drop]reader": (handle: number) => readers.delete(handle),
+        "[method]reader.read": (handle: number, pointer: number, length: number) => {
+          const reader = readers.get(handle);
+          if (!reader) {
+            throw new Error("Data loader requested an unknown file reader");
+          }
+          const chunk = reader.bytes.subarray(reader.position, reader.position + length);
+          memory(getInstance()).set(chunk, pointer);
+          reader.position += chunk.length;
+          return BigInt(chunk.length);
+        },
+        "[method]reader.seek": (handle: number, position: bigint) => {
+          const reader = readers.get(handle);
+          if (!reader || position > BigInt(reader.bytes.length)) {
+            throw new Error("Data loader attempted an invalid file seek");
+          }
+          reader.position = Number(position);
+          return position;
+        },
+        "[method]reader.position": (handle: number) => BigInt(readers.get(handle)?.position ?? 0),
+        "[method]reader.size": (handle: number) => BigInt(readers.get(handle)?.bytes.length ?? 0),
+        open: (pointer: number, length: number) => {
+          const path = readString(getInstance(), pointer, length);
+          const index = paths.indexOf(path);
+          if (index < 0) {
+            throw new Error("Data loader requested a file that was not selected");
+          }
+          const handle = nextReader++;
+          readers.set(handle, { bytes: fileBytes[index]!, position: 0 });
+          return handle;
+        },
+      },
+      [EXPORT_MODULE]: {
+        "[resource-new]data-loader": (representation: number) => representation,
+        "[resource-drop]data-loader": (_representation: number) => {},
+        "[resource-new]message-iterator": (representation: number) => representation,
+        "[resource-drop]message-iterator": (_representation: number) => {},
+      },
+      "foxglove:loader/console@0.1.0": {
+        log: (pointer: number, length: number) =>
+          console.info(readString(getInstance(), pointer, length)),
+        warn: (pointer: number, length: number) =>
+          console.warn(readString(getInstance(), pointer, length)),
+        error: (pointer: number, length: number) =>
+          console.error(readString(getInstance(), pointer, length)),
+      },
+    };
+    const wasm = decodeDataUrl(this.#wasmUrl);
+    const result = await WebAssembly.instantiate(wasm, imports);
+    instance = { exports: result.instance.exports as LoaderInstance["exports"], paths, readers };
+    this.#instance = instance;
+
+    const pointer = allocate(instance, paths.length * 8, 4);
+    const data = view(instance);
+    for (const [index, path] of paths.entries()) {
+      const encoded = textEncoder.encode(path);
+      const stringPointer = allocate(instance, encoded.length, 1);
+      memory(instance).set(encoded, stringPointer);
+      data.setUint32(pointer + index * 8, stringPointer, true);
+      data.setUint32(pointer + index * 8 + 4, encoded.length, true);
+    }
+    this.#loader = exportedFunction(instance, `${LOADER_EXPORT}#[constructor]data-loader`)(
+      pointer,
+      paths.length,
+    );
+    const resultPointer = exportedFunction(
+      instance,
+      `${LOADER_EXPORT}#[method]data-loader.initialize`,
+    )(this.#loader);
+    if (view(instance).getUint32(resultPointer, true) !== 0) {
+      throw new Error(loaderError(instance, resultPointer));
+    }
+    const init = view(instance);
+    const channels = decodeChannels(
+      instance,
+      init.getUint32(resultPointer + 8, true),
+      init.getUint32(resultPointer + 12, true),
+    );
+    const schemas = decodeSchemas(
+      instance,
+      init.getUint32(resultPointer + 16, true),
+      init.getUint32(resultPointer + 20, true),
+    );
+    const start = fromNanoSec(readU64(init, resultPointer + 24));
+    const end = fromNanoSec(readU64(init, resultPointer + 32));
+    channels.forEach((channel) => this.#channels.set(channel.id, channel));
+    schemas.forEach((schema) => this.#schemas.set(schema.id, schema));
+    const datatypes: RosDatatypes = new Map();
+    for (const channel of channels) {
+      const schema =
+        channel.schemaId == undefined ? undefined : this.#schemas.get(channel.schemaId);
+      const parsedChannel = parseChannel(
+        {
+          messageEncoding: channel.messageEncoding,
+          schema:
+            schema == undefined
+              ? undefined
+              : { name: schema.name, encoding: schema.encoding, data: schema.data },
+        },
+        { allowEmptySchema: true },
+      );
+      this.#parsedChannels.set(channel.id, parsedChannel);
+      for (const [name, datatype] of parsedChannel.datatypes) {
+        datatypes.set(name, datatype);
+      }
+    }
+    exportedFunction(
+      instance,
+      `cabi_post_${LOADER_EXPORT}#[method]data-loader.initialize`,
+    )(resultPointer);
+
+    const topics: Topic[] = channels.map((channel) => ({
+      name: channel.topicName,
+      schemaName:
+        channel.schemaId == undefined
+          ? ""
+          : (schemas.find((schema) => schema.id === channel.schemaId)?.name ?? ""),
+    }));
+    const topicStats = new Map<string, TopicStats>(
+      channels.map((channel) => [
+        channel.topicName,
+        { numMessages: Number(channel.messageCount ?? 0n) },
+      ]),
+    );
+    return {
+      start,
+      end,
+      topics,
+      topicStats,
+      datatypes,
+      profile: undefined,
+      publishersByTopic: new Map(),
+      problems: [],
+    };
+  }
+
+  public async *messageIterator(
+    args: Immutable<MessageIteratorArgs>,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+    const instance = this.#requireInstance();
+    const loader = this.#requireLoader();
+    const channelIds = Array.from(args.topics.keys())
+      .map(
+        (topic) =>
+          Array.from(this.#channels.values()).find((channel) => channel.topicName === topic)?.id,
+      )
+      .filter((id): id is number => id != undefined);
+    const pointer = allocate(instance, channelIds.length * 2, 2);
+    const data = view(instance);
+    channelIds.forEach((id, index) => data.setUint16(pointer + index * 2, id, true));
+    const iteratorResult = exportedFunction(
+      instance,
+      `${LOADER_EXPORT}#[method]data-loader.create-iterator`,
+    )(
+      loader,
+      args.start == undefined ? 0 : 1,
+      args.start == undefined ? 0n : toNanoSec(args.start),
+      args.end == undefined ? 0 : 1,
+      args.end == undefined ? 0n : toNanoSec(args.end),
+      pointer,
+      channelIds.length,
+    );
+    if (view(instance).getUint32(iteratorResult, true) !== 0) {
+      throw new Error(loaderError(instance, iteratorResult));
+    }
+    const iterator = view(instance).getUint32(iteratorResult + 4, true);
+    exportedFunction(
+      instance,
+      `cabi_post_${LOADER_EXPORT}#[method]data-loader.create-iterator`,
+    )(iteratorResult);
+    while (true) {
+      const nextResult = exportedFunction(
+        instance,
+        `${LOADER_EXPORT}#[method]message-iterator.next`,
+      )(iterator);
+      const tag = view(instance).getUint32(nextResult, true);
+      if (tag === 0) {
+        exportedFunction(
+          instance,
+          `cabi_post_${LOADER_EXPORT}#[method]message-iterator.next`,
+        )(nextResult);
+        return;
+      }
+      if (tag !== 1) {
+        const message = loaderError(instance, nextResult);
+        exportedFunction(
+          instance,
+          `cabi_post_${LOADER_EXPORT}#[method]message-iterator.next`,
+        )(nextResult);
+        throw new Error(message);
+      }
+      const message = decodeMessage(instance, nextResult + 16);
+      exportedFunction(
+        instance,
+        `cabi_post_${LOADER_EXPORT}#[method]message-iterator.next`,
+      )(nextResult);
+      yield { type: "message-event", msgEvent: this.#toMessageEvent(message) };
+    }
+  }
+
+  public async getBackfillMessages(
+    args: Immutable<GetBackfillMessagesArgs>,
+  ): Promise<MessageEvent[]> {
+    const instance = this.#requireInstance();
+    const loader = this.#requireLoader();
+    const channelIds = Array.from(args.topics.keys())
+      .map(
+        (topic) =>
+          Array.from(this.#channels.values()).find((channel) => channel.topicName === topic)?.id,
+      )
+      .filter((id): id is number => id != undefined);
+    const pointer = allocate(instance, channelIds.length * 2, 2);
+    const data = view(instance);
+    channelIds.forEach((id, index) => data.setUint16(pointer + index * 2, id, true));
+    const resultPointer = exportedFunction(
+      instance,
+      `${LOADER_EXPORT}#[method]data-loader.get-backfill`,
+    )(loader, toNanoSec(args.time), pointer, channelIds.length);
+    if (view(instance).getUint32(resultPointer, true) !== 0) {
+      throw new Error(loaderError(instance, resultPointer));
+    }
+    const messagesPointer = view(instance).getUint32(resultPointer + 8, true);
+    const messagesLength = view(instance).getUint32(resultPointer + 12, true);
+    const messages = Array.from({ length: messagesLength }, (_unused, index) =>
+      this.#toMessageEvent(decodeMessage(instance, messagesPointer + index * 32)),
+    );
+    exportedFunction(
+      instance,
+      `cabi_post_${LOADER_EXPORT}#[method]data-loader.get-backfill`,
+    )(resultPointer);
+    return messages;
+  }
+
+  #toMessageEvent(message: LoaderMessage): MessageEvent {
+    const channel = this.#channels.get(message.channelId);
+    if (!channel) {
+      throw new Error(`Data loader emitted unknown channel ${message.channelId}`);
+    }
+    const schema = channel.schemaId == undefined ? undefined : this.#schemas.get(channel.schemaId);
+    const parsedChannel = this.#parsedChannels.get(message.channelId);
+    if (!parsedChannel) {
+      throw new Error(
+        `Data loader emitted a channel that was not initialized: ${message.channelId}`,
+      );
+    }
+    return {
+      topic: channel.topicName,
+      schemaName: schema?.name ?? "",
+      receiveTime: fromNanoSec(message.logTime),
+      publishTime: fromNanoSec(message.publishTime),
+      message: parsedChannel.deserialize(message.data),
+      sizeInBytes: message.data.byteLength,
+    };
+  }
+
+  #requireInstance(): LoaderInstance {
+    if (!this.#instance) {
+      throw new Error("Data loader must be initialized before reading messages");
+    }
+    return this.#instance;
+  }
+
+  #requireLoader(): number {
+    if (this.#loader == undefined) {
+      throw new Error("Data loader must be initialized before reading messages");
+    }
+    return this.#loader;
+  }
+}

--- a/packages/suite-base/src/players/IterablePlayer/WasmDataLoader/WasmDataLoaderIterableSource.ts
+++ b/packages/suite-base/src/players/IterablePlayer/WasmDataLoader/WasmDataLoaderIterableSource.ts
@@ -5,7 +5,7 @@
 import { fromNanoSec, toNanoSec } from "@lichtblick/rostime";
 import { Immutable, MessageEvent } from "@lichtblick/suite";
 import { ParsedChannel, parseChannel } from "@lichtblick/mcap-support";
-import { PlayerProblem, Topic, TopicStats } from "@lichtblick/suite-base/players/types";
+import { Topic, TopicStats } from "@lichtblick/suite-base/players/types";
 import { RosDatatypes } from "@lichtblick/suite-base/types/RosDatatypes";
 
 import {
@@ -246,8 +246,9 @@ export class WasmDataLoaderIterableSource implements IIterableSource {
       },
     };
     const wasm = decodeDataUrl(this.#wasmUrl);
-    const result = await WebAssembly.instantiate(wasm, imports);
-    instance = { exports: result.instance.exports as LoaderInstance["exports"], paths, readers };
+    const module = await WebAssembly.compile(wasm);
+    const wasmInstance = await WebAssembly.instantiate(module, imports);
+    instance = { exports: wasmInstance.exports as LoaderInstance["exports"], paths, readers };
     this.#instance = instance;
 
     const pointer = allocate(instance, paths.length * 8, 4);

--- a/packages/suite-base/src/providers/ExtensionCatalogProvider.test.tsx
+++ b/packages/suite-base/src/providers/ExtensionCatalogProvider.test.tsx
@@ -228,6 +228,41 @@ describe("ExtensionCatalogProvider", () => {
     ]);
   });
 
+  it("registers a data loader contribution", async () => {
+    const source = `
+      module.exports = {
+        activate: function(ctx) {
+          ctx.registerDataLoader({
+            type: "file",
+            wasmUrl: "data:application/wasm;base64,AGFzbQ==",
+            supportedFileType: ".flora-test",
+          });
+        }
+      };
+    `;
+    const extension = ExtensionBuilder.extensionInfo();
+    const loadExtension = jest.fn().mockResolvedValue(source);
+    const loader: ExtensionLoader = {
+      namespace: extension.namespace!,
+      getExtension: jest.fn(),
+      getExtensions: jest.fn().mockResolvedValue([extension]),
+      installExtension: jest.fn(),
+      loadExtension,
+      uninstallExtension: jest.fn(),
+    };
+
+    const { result } = setup({ loadersOverride: [loader] });
+
+    await waitFor(() => {
+      expect(result.current.installedDataLoaders).toEqual([
+        expect.objectContaining({
+          extensionId: extension.id,
+          supportedFileType: ".flora-test",
+        }),
+      ]);
+    });
+  });
+
   it("should register a default config", async () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
 
@@ -394,6 +429,7 @@ describe("ExtensionCatalogProvider", () => {
         { extensionId: extensionInfo.id, aliasFunction: jest.fn() },
       ];
       const contributionPoints: ContributionPoints = {
+        dataLoaders: [],
         messageConverters: [messageConverter],
         topicAliasFunctions,
         panelSettings: {

--- a/packages/suite-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/suite-base/src/providers/ExtensionCatalogProvider.tsx
@@ -87,7 +87,13 @@ function createExtensionRegistryStore(
 
     const mergeState = (
       info: ExtensionInfo,
-      { messageConverters, panelSettings, panels, topicAliasFunctions }: ContributionPoints,
+      {
+        dataLoaders,
+        messageConverters,
+        panelSettings,
+        panels,
+        topicAliasFunctions,
+      }: ContributionPoints,
     ) => {
       set((state) => ({
         installedExtensions: _.uniqBy([...(state.installedExtensions ?? []), info], "id"),
@@ -95,6 +101,10 @@ function createExtensionRegistryStore(
         installedMessageConverters: _.uniqBy(
           [...state.installedMessageConverters!, ...messageConverters],
           "extensionId",
+        ),
+        installedDataLoaders: _.uniqBy(
+          [...state.installedDataLoaders!, ...dataLoaders],
+          (dataLoader) => `${dataLoader.extensionId}:${dataLoader.supportedFileType}`,
         ),
         installedTopicAliasFunctions: _.uniqBy(
           [...state.installedTopicAliasFunctions!, ...topicAliasFunctions],
@@ -120,7 +130,7 @@ function createExtensionRegistryStore(
           try {
             installedExtensions.push(extension);
 
-            const { messageConverters, panelSettings, panels, topicAliasFunctions } =
+            const { dataLoaders, messageConverters, panelSettings, panels, topicAliasFunctions } =
               contributionPoints;
             const unwrappedExtensionSource = await loader.loadExtension(extension.id);
             const newContributionPoints = buildContributionPoints(
@@ -131,6 +141,7 @@ function createExtensionRegistryStore(
             _.assign(panels, newContributionPoints.panels);
             _.merge(panelSettings, newContributionPoints.panelSettings);
             messageConverters.push(...newContributionPoints.messageConverters);
+            dataLoaders.push(...newContributionPoints.dataLoaders);
             topicAliasFunctions.push(...newContributionPoints.topicAliasFunctions);
 
             get().markExtensionAsInstalled(extension.id);
@@ -150,6 +161,7 @@ function createExtensionRegistryStore(
       const start = performance.now();
       const installedExtensions: ExtensionInfo[] = [];
       const contributionPoints: ContributionPoints = {
+        dataLoaders: [],
         messageConverters: [],
         panels: {},
         panelSettings: {},
@@ -182,6 +194,7 @@ function createExtensionRegistryStore(
         installedExtensions,
         installedPanels: contributionPoints.panels,
         installedMessageConverters: contributionPoints.messageConverters,
+        installedDataLoaders: contributionPoints.dataLoaders,
         installedTopicAliasFunctions: contributionPoints.topicAliasFunctions,
         panelSettings: contributionPoints.panelSettings,
       });
@@ -196,6 +209,7 @@ function createExtensionRegistryStore(
         ExtensionCatalog,
         | "installedExtensions"
         | "installedPanels"
+        | "installedDataLoaders"
         | "installedMessageConverters"
         | "installedTopicAliasFunctions"
       >;
@@ -203,6 +217,7 @@ function createExtensionRegistryStore(
       const {
         installedExtensions,
         installedPanels,
+        installedDataLoaders,
         installedMessageConverters,
         installedTopicAliasFunctions,
       } = state;
@@ -212,6 +227,7 @@ function createExtensionRegistryStore(
           ({ id: extensionId }) => extensionId !== id,
         ),
         installedPanels: _.pickBy(installedPanels, ({ extensionId }) => extensionId !== id),
+        installedDataLoaders: installedDataLoaders?.filter(({ extensionId }) => extensionId !== id),
         installedMessageConverters: installedMessageConverters?.filter(
           ({ extensionId }) => extensionId !== id,
         ),
@@ -248,6 +264,7 @@ function createExtensionRegistryStore(
       unMarkExtensionAsInstalled,
       installedExtensions: loaders.length === 0 ? [] : undefined,
       installedMessageConverters: mockMessageConverters ?? [],
+      installedDataLoaders: [],
       installedPanels: {},
       installedTopicAliasFunctions: [],
       loadedExtensions: new Set<string>(),

--- a/packages/suite-base/src/providers/helpers/buildContributionPoints.test.ts
+++ b/packages/suite-base/src/providers/helpers/buildContributionPoints.test.ts
@@ -23,6 +23,7 @@ describe("buildContributionPoints", () => {
     expect(result).toHaveProperty("panels", {});
     expect(result).toHaveProperty("messageConverters", []);
     expect(result).toHaveProperty("topicAliasFunctions", []);
+    expect(result).toHaveProperty("dataLoaders", []);
     expect(result).toHaveProperty("panelSettings", {});
     consoleErrorMock.mockRestore();
   });
@@ -190,5 +191,34 @@ describe("buildContributionPoints", () => {
     expect(result.topicAliasFunctions[0]!.extensionId).toBe(extensionInfo.id);
     expect(result.topicAliasFunctions[0]!.aliasFunction).toBe(aliasFunction);
     delete (globalThis as any).topicAliasFunction;
+  });
+
+  it("registers an inline WASM data loader", () => {
+    const extensionInfo = ExtensionBuilder.extensionInfo();
+    const extensionSource = `
+      module.exports = {
+        activate: (ctx) => {
+          ctx.registerDataLoader({
+            type: "file",
+            wasmUrl: "data:application/wasm;base64,AGFzbQ==",
+            supportedFileType: ".example",
+            supportsMultiFile: true,
+          });
+        }
+      };
+    `;
+
+    const result = buildContributionPoints(extensionInfo, extensionSource);
+
+    expect(result.dataLoaders).toEqual([
+      {
+        extensionId: extensionInfo.id,
+        extensionNamespace: extensionInfo.namespace,
+        supportedFileType: ".example",
+        supportsMultiFile: true,
+        type: "file",
+        wasmUrl: "data:application/wasm;base64,AGFzbQ==",
+      },
+    ]);
   });
 });

--- a/packages/suite-base/src/providers/helpers/buildContributionPoints.ts
+++ b/packages/suite-base/src/providers/helpers/buildContributionPoints.ts
@@ -39,14 +39,16 @@ export function buildContributionPoints(
   log.debug(`Mounting extension ${extension.qualifiedName}`);
 
   const module = { exports: {} };
+  const floraExtensionPackage = ["@flora-suite", "extension"].join("/");
+  const floraSchemasPackage = ["@flora-suite", "schemas"].join("/");
   const require = (name: string): unknown => {
     const modules: Record<string, unknown> = {
       react: React,
       "react-dom": ReactDOM,
-      // Flora extension API packages contain compile-time contracts. Returning an empty module
-      // keeps type-only imports safe even when a bundler preserves an import expression.
-      "@flora-suite/extension": {},
-      "@flora-suite/schemas": {},
+      // The Flora API packages contain compile-time contracts. An empty runtime module keeps
+      // type-only imports safe when a bundler preserves an import expression.
+      [floraExtensionPackage]: {},
+      [floraSchemasPackage]: {},
     };
     return modules[name];
   };

--- a/packages/suite-base/src/providers/helpers/buildContributionPoints.ts
+++ b/packages/suite-base/src/providers/helpers/buildContributionPoints.ts
@@ -80,7 +80,7 @@ export function buildContributionPoints(
       };
     },
 
-    registerMessageConverter: <Src>(messageConverter: RegisterMessageConverterArgs<Src>) => {
+    registerMessageConverter: function <Src>(messageConverter: RegisterMessageConverterArgs<Src>) {
       log.debug(
         `Extension ${extension.qualifiedName} registering message converter from: ${messageConverter.fromSchemaName} to: ${messageConverter.toSchemaName}`,
       );

--- a/packages/suite-base/src/providers/helpers/buildContributionPoints.ts
+++ b/packages/suite-base/src/providers/helpers/buildContributionPoints.ts
@@ -8,7 +8,7 @@ import ReactDOM from "react-dom";
 import Logger from "@lichtblick/log";
 import {
   RegisterMessageConverterArgs,
-  ExtensionContext,
+  Experimental,
   TopicAliasFunction,
   ExtensionModule,
   ExtensionPanelRegistration,
@@ -16,6 +16,7 @@ import {
 import { ExtensionSettings } from "@lichtblick/suite-base/components/PanelSettings/types";
 import {
   ContributionPoints,
+  RegisteredDataLoader,
   RegisteredPanel,
   MessageConverter,
 } from "@lichtblick/suite-base/context/ExtensionCatalogContext";
@@ -33,12 +34,21 @@ export function buildContributionPoints(
   const messageConverters: RegisterMessageConverterArgs<unknown>[] = [];
   const panelSettings: ExtensionSettings = {};
   const topicAliasFunctions: ContributionPoints["topicAliasFunctions"] = [];
+  const dataLoaders: RegisteredDataLoader[] = [];
 
   log.debug(`Mounting extension ${extension.qualifiedName}`);
 
   const module = { exports: {} };
-  const require = (name: string) => {
-    return { react: React, "react-dom": ReactDOM }[name];
+  const require = (name: string): unknown => {
+    const modules: Record<string, unknown> = {
+      react: React,
+      "react-dom": ReactDOM,
+      // Flora extension API packages contain compile-time contracts. Returning an empty module
+      // keeps type-only imports safe even when a bundler preserves an import expression.
+      "@flora-suite/extension": {},
+      "@flora-suite/schemas": {},
+    };
+    return modules[name];
   };
 
   const extensionMode =
@@ -48,7 +58,7 @@ export function buildContributionPoints(
         ? "test"
         : "development";
 
-  const ctx: ExtensionContext = {
+  const ctx: Experimental.ExtensionContext = {
     mode: extensionMode,
 
     registerPanel: (registration: ExtensionPanelRegistration) => {
@@ -68,7 +78,7 @@ export function buildContributionPoints(
       };
     },
 
-    registerMessageConverter: <Src,>(messageConverter: RegisterMessageConverterArgs<Src>) => {
+    registerMessageConverter: <Src>(messageConverter: RegisterMessageConverterArgs<Src>) => {
       log.debug(
         `Extension ${extension.qualifiedName} registering message converter from: ${messageConverter.fromSchemaName} to: ${messageConverter.toSchemaName}`,
       );
@@ -89,6 +99,32 @@ export function buildContributionPoints(
     registerTopicAliases: (aliasFunction: TopicAliasFunction) => {
       topicAliasFunctions.push({ aliasFunction, extensionId: extension.id });
     },
+
+    registerDataLoader: (registration: Experimental.DataLoaderRegistration) => {
+      if (registration.type !== "file") {
+        log.error(
+          `Extension ${extension.qualifiedName} registered an unsupported data loader type`,
+        );
+        return;
+      }
+      if (!registration.supportedFileType.startsWith(".")) {
+        log.error(
+          `Extension ${extension.qualifiedName} registered a data loader without a file suffix`,
+        );
+        return;
+      }
+      if (!registration.wasmUrl.startsWith("data:application/wasm;base64,")) {
+        log.error(
+          `Extension ${extension.qualifiedName} registered a data loader without an inline WASM module`,
+        );
+        return;
+      }
+      dataLoaders.push({
+        ...registration,
+        extensionId: extension.id,
+        extensionNamespace: extension.namespace,
+      });
+    },
   };
 
   try {
@@ -108,6 +144,7 @@ export function buildContributionPoints(
     panels,
     messageConverters,
     topicAliasFunctions,
+    dataLoaders,
     panelSettings,
   };
 }

--- a/packages/suite-desktop/src/preload/index.ts
+++ b/packages/suite-desktop/src/preload/index.ts
@@ -17,6 +17,7 @@ import { decodeRendererArg } from "../common/rendererArgs";
 import {
   CLIFlags,
   Desktop,
+  DesktopExtension,
   ForwardedMenuEvent,
   ForwardedWindowEvent,
   NativeMenuBridge,
@@ -30,7 +31,9 @@ import { FLORA_PRODUCT_NAME, FLORA_PRODUCT_VERSION } from "../common/webpackDefi
 const ignoreDeepLinks = document.cookie.includes("fox.ignoreDeepLinks=true");
 document.cookie = "fox.ignoreDeepLinks=;max-age=0;";
 
-const deepLinks = ignoreDeepLinks ? [] : decodeRendererArg("deepLinks", window.process.argv) ?? [];
+const deepLinks = ignoreDeepLinks
+  ? []
+  : (decodeRendererArg("deepLinks", window.process.argv) ?? []);
 
 export function main(): void {
   const log = Logger.getLogger(__filename);
@@ -67,6 +70,16 @@ export function main(): void {
   );
 
   const localFileStorage = new LocalFileStorage();
+
+  const extensionRoots = async (): Promise<string[]> => {
+    const homePath = (await ipcRenderer.invoke("getHomePath")) as string;
+    // Flora owns the new location. Keep the Lichtblick path readable so existing users do not
+    // lose manually installed extensions during the product rename.
+    return [
+      pathJoin(homePath, ".flora", "extensions"),
+      pathJoin(homePath, ".lichtblick-suite", "extensions"),
+    ];
+  };
 
   const ctx: OsContext = {
     platform: process.platform,
@@ -132,15 +145,22 @@ export function main(): void {
       window.location.reload();
     },
     async getExtensions() {
-      const homePath = (await ipcRenderer.invoke("getHomePath")) as string;
-      const userExtensionRoot = pathJoin(homePath, ".lichtblick-suite", "extensions");
-      const userExtensions = await getExtensions(userExtensionRoot);
-      return userExtensions;
+      const extensions = await Promise.all((await extensionRoots()).map(getExtensions));
+      const uniqueExtensions = new Map<string, DesktopExtension>();
+      for (const extension of extensions.flat()) {
+        // The Flora location is first and wins when an extension is installed in both roots.
+        uniqueExtensions.set(extension.id, uniqueExtensions.get(extension.id) ?? extension);
+      }
+      return [...uniqueExtensions.values()];
     },
     async loadExtension(id: string) {
-      const homePath = (await ipcRenderer.invoke("getHomePath")) as string;
-      const userExtensionRoot = pathJoin(homePath, ".lichtblick-suite", "extensions");
-      return await loadExtension(id, userExtensionRoot);
+      for (const root of await extensionRoots()) {
+        const source = await loadExtension(id, root);
+        if (source.length > 0) {
+          return source;
+        }
+      }
+      return "";
     },
     async fetchLayouts() {
       const homePath = (await ipcRenderer.invoke("getHomePath")) as string;
@@ -148,14 +168,14 @@ export function main(): void {
       return await fetchLayouts(userExtensionRoot);
     },
     async installExtension(foxeFileData: Uint8Array) {
-      const homePath = (await ipcRenderer.invoke("getHomePath")) as string;
-      const userExtensionRoot = pathJoin(homePath, ".lichtblick-suite", "extensions");
-      return await installExtension(foxeFileData, userExtensionRoot);
+      const [floraExtensionRoot] = await extensionRoots();
+      return await installExtension(foxeFileData, floraExtensionRoot!);
     },
     async uninstallExtension(id: string): Promise<boolean> {
-      const homePath = (await ipcRenderer.invoke("getHomePath")) as string;
-      const userExtensionRoot = pathJoin(homePath, ".lichtblick-suite", "extensions");
-      return await uninstallExtension(id, userExtensionRoot);
+      const results = await Promise.all(
+        (await extensionRoots()).map((root) => uninstallExtension(id, root)),
+      );
+      return results.some(Boolean);
     },
     handleTitleBarDoubleClick() {
       ipcRenderer.send("titleBarDoubleClicked");

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -502,6 +502,24 @@ export interface ExtensionContext {
   registerTopicAliases(aliasFunction: TopicAliasFunction): void;
 }
 
+type BaseExtensionContext = ExtensionContext;
+
+/** Experimental extension APIs backed by the Flora desktop data-source runtime. */
+export namespace Experimental {
+  export type DataLoaderRegistration = {
+    type: "file";
+    /** A data URL containing a WebAssembly module compatible with foxglove:loader@0.1.0. */
+    wasmUrl: string;
+    /** A file suffix, including its leading period (for example, `.csv`). */
+    supportedFileType: string;
+    supportsMultiFile?: boolean;
+  };
+
+  export interface ExtensionContext extends BaseExtensionContext {
+    registerDataLoader(registration: DataLoaderRegistration): void;
+  }
+}
+
 export type ExtensionActivate = (extensionContext: ExtensionContext) => void;
 
 // ExtensionModule describes the interface your extension entry level module must export


### PR DESCRIPTION
## Summary
- store new Flora desktop extensions under ~/.flora/extensions while retaining read compatibility for legacy extensions
- expose extension data-loader registrations and dynamic file data sources
- execute the supported WebAssembly loader ABI against user-selected files and use existing schema deserializers

## Verification
- targeted Jest suites: 21 tests passed
- Prettier check for changed source files
- exercised the runtime against packaged CSV and NDJSON extension artifacts