### PR TITLE
ci: recycle memory-heavy Jest workers

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -6,5 +6,6 @@
     "<rootDir>/packages/*/jest.config.json"
   ],
   "coverageDirectory": "coverage",
-  "testEnvironment": "jsdom"
+  "testEnvironment": "jsdom",
+  "workerIdleMemoryLimit": "1GB"
 }


### PR DESCRIPTION
## Summary

Recycle Jest workers after a suite reaches 1 GB idle memory.

## Why

The complete suite reaches Node's 4 GB heap limit even with one worker, showing per-suite memory accumulation rather than just excessive parallelism. Jest's `workerIdleMemoryLimit` resets a worker between suites while retaining safe parallel throughput.

## Validation

- `yarn install --immutable` completed in an isolated worktree.
- `yarn jest --showConfig` resolves `workerIdleMemoryLimit` to `1000000000` bytes.
- `git diff --check`
- GitHub Actions is running the complete suite against the updated setting.