### PR TITLE
fix: upgrade Monaco Editor to 0.56

### DIFF
--- a/packages/suite-base/package.json
+++ b/packages/suite-base/package.json
@@ -144,7 +144,7 @@
     "moment": "2.30.1",
     "moment-duration-format": "2.3.2",
     "moment-timezone": "0.6.0",
-    "monaco-editor": "0.55.1",
+    "monaco-editor": "0.56.0",
     "monaco-editor-webpack-plugin": "7.1.1",
     "natsort": "2.0.3",
     "nearley": "2.20.1",

--- a/packages/suite-base/src/panels/UserScriptEditor/Editor.tsx
+++ b/packages/suite-base/src/panels/UserScriptEditor/Editor.tsx
@@ -12,13 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { useTheme } from "@mui/material";
-// @ts-expect-error ICodeEditorService does not have type information in the monaco-editor package
-import { ICodeEditorService } from "monaco-editor/esm/vs/editor/browser/services/codeEditorService";
-import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
-// @ts-expect-error monaco.contribution exports these values at runtime but ships an empty d.ts
-import { javascriptDefaults, typescriptDefaults } from "monaco-editor/esm/vs/language/typescript/monaco.contribution";
-// @ts-expect-error StandaloneService does not have type information in the monaco-editor package
-import { StandaloneServices } from "monaco-editor/esm/vs/editor/standalone/browser/standaloneServices";
+import * as monacoApi from "monaco-editor";
 import * as path from "path";
 import React, { Suspense, ReactElement, useCallback, useEffect, useRef } from "react";
 import MonacoEditor, { EditorDidMount, EditorWillMount } from "react-monaco-editor";
@@ -36,7 +30,7 @@ import { mightActuallyBePartial } from "@lichtblick/suite-base/util/mightActuall
 
 import { themes } from "./theme";
 
-const codeEditorService = StandaloneServices.get(ICodeEditorService);
+const { javascriptDefaults, typescriptDefaults } = monacoApi.typescript;
 
 type CodeEditor = monacoApi.editor.ICodeEditor;
 
@@ -53,7 +47,10 @@ type Props = {
 
 // Taken from:
 // https://github.com/microsoft/vscode/blob/master/src/vs/editor/standalone/browser/standaloneCodeServiceImpl.ts
-const gotoSelection = (editor: monacoApi.editor.IEditor, selection?: monacoApi.IRange) => {
+const gotoSelection = (
+  editor: monacoApi.editor.IEditor,
+  selection?: monacoApi.IRange | monacoApi.IPosition,
+) => {
   if (selection) {
     const maybeSelection = mightActuallyBePartial(selection);
     if (maybeSelection.endLineNumber != undefined && maybeSelection.endColumn != undefined) {
@@ -66,13 +63,9 @@ const gotoSelection = (editor: monacoApi.editor.IEditor, selection?: monacoApi.I
       );
     } else {
       // Otherwise it's just a position
-      const pos = {
-        lineNumber: selection.startLineNumber,
-        column: selection.startColumn,
-      };
-      editor.setPosition(pos);
+      editor.setPosition(selection);
       editor.revealPositionInCenter(
-        pos,
+        selection,
         1,
         /* Immediate */
       );
@@ -124,18 +117,11 @@ const Editor = ({
   selection to move to the correct line.
   */
   useEffect(() => {
-    const disposable = codeEditorService.registerCodeEditorOpenHandler(
-      async (
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        input: any,
-        // eslint-disable-next-line no-restricted-syntax
-        editor: monacoApi.editor.ICodeEditor | null,
-        // eslint-disable-next-line no-restricted-syntax
-      ): Promise<monacoApi.editor.ICodeEditor | null> => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        const requestedModel = monacoApi.editor.getModel(input.resource);
+    const disposable = monacoApi.editor.registerEditorOpener({
+      openCodeEditor: async (editor, resource, selection) => {
+        const requestedModel = monacoApi.editor.getModel(resource);
         if (!requestedModel) {
-          return editor;
+          return false;
         }
 
         // If we are jumping to a definition within the user node, don't push
@@ -144,23 +130,22 @@ const Editor = ({
           editor &&
           script &&
           requestedModel.uri.path ===
-          `${DEFAULT_STUDIO_SCRIPT_PREFIX}${path.basename(script.filePath)}`
+            `${DEFAULT_STUDIO_SCRIPT_PREFIX}${path.basename(script.filePath)}`
         ) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          gotoSelection(editor, input.options.selection);
-          // eslint-disable-next-line no-restricted-syntax
-          return null;
+          gotoSelection(editor, selection);
+          return true;
         }
 
         setScriptOverride({
           filePath: requestedModel.uri.path,
           code: requestedModel.getValue(),
           readOnly: true,
-          selection: input.options?.selection,
+          selection,
         });
-        return editor;
+        return true;
       },
-    );
+    });
     return () => disposable.dispose();
   }, [script, setScriptOverride]);
 
@@ -248,10 +233,7 @@ const Editor = ({
       // typescript language service does not expose such a method.
       projectConfig.declarations.forEach((lib) => {
         if (lib.fileName.startsWith("@foxglove/schemas")) {
-          typescriptDefaults.addExtraLib(
-            lib.sourceCode,
-            `file:///node_modules/${lib.fileName}`,
-          );
+          typescriptDefaults.addExtraLib(lib.sourceCode, `file:///node_modules/${lib.fileName}`);
         } else {
           typescriptDefaults.addExtraLib(
             lib.sourceCode,

--- a/packages/suite-base/src/panels/UserScriptEditor/Sidebar/index.tsx
+++ b/packages/suite-base/src/panels/UserScriptEditor/Sidebar/index.tsx
@@ -8,7 +8,7 @@ import {
   Toolbox24Regular,
 } from "@fluentui/react-icons";
 import { Divider, Paper, Tab, Tabs, tabClasses, tabsClasses } from "@mui/material";
-import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
+import * as monacoApi from "monaco-editor";
 import { SyntheticEvent, useCallback, useMemo, useState } from "react";
 import tc from "tinycolor2";
 import { makeStyles } from "tss-react/mui";

--- a/packages/suite-base/src/panels/UserScriptEditor/script.ts
+++ b/packages/suite-base/src/panels/UserScriptEditor/script.ts
@@ -11,11 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { IRange } from "monaco-editor/esm/vs/editor/editor.api";
+import type { IPosition, IRange } from "monaco-editor";
 
 export type Script = {
   filePath: string;
   code: string;
   readOnly: boolean;
-  selection?: IRange;
+  selection?: IRange | IPosition;
 };

--- a/packages/suite-base/src/panels/UserScriptEditor/theme/index.ts
+++ b/packages/suite-base/src/panels/UserScriptEditor/theme/index.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
+import * as monacoApi from "monaco-editor";
 
 import vsStudioDarkTheme from "./vs-studio-dark";
 import vsStudioLightTheme from "./vs-studio-light";

--- a/packages/suite-base/src/panels/UserScriptEditor/theme/vs-studio-dark.ts
+++ b/packages/suite-base/src/panels/UserScriptEditor/theme/vs-studio-dark.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable filenames/match-exported */
 
-import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
+import * as monacoApi from "monaco-editor";
 
 const theme: monacoApi.editor.IStandaloneThemeData = {
   base: "vs-dark",

--- a/packages/suite-base/src/panels/UserScriptEditor/theme/vs-studio-light.ts
+++ b/packages/suite-base/src/panels/UserScriptEditor/theme/vs-studio-light.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable filenames/match-exported */
 
-import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
+import * as monacoApi from "monaco-editor";
 
 const theme: monacoApi.editor.IStandaloneThemeData = {
   base: "vs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4169,7 +4169,7 @@ __metadata:
     moment: "npm:2.30.1"
     moment-duration-format: "npm:2.3.2"
     moment-timezone: "npm:0.6.0"
-    monaco-editor: "npm:0.55.1"
+    monaco-editor: "npm:0.56.0"
     monaco-editor-webpack-plugin: "npm:7.1.1"
     natsort: "npm:2.0.3"
     nearley: "npm:2.20.1"
@@ -11654,18 +11654,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.2.7":
-  version: 3.2.7
-  resolution: "dompurify@npm:3.2.7"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10c0/d41bb31a72f1acdf9b84c56723c549924b05d92a39a15bd8c40bec9007ff80d5fccf844bc53ee12af5b69044f9a7ce24a1e71c267a4f49cf38711379ed8c1363
-  languageName: node
-  linkType: hard
-
 "dompurify@npm:3.3.1":
   version: 3.3.1
   resolution: "dompurify@npm:3.3.1"
@@ -11675,6 +11663,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: 10c0/fa0a8c55a436ba0d54389195e3d2337e311f56de709a2fc9efc98dbbc7746fa53bb4b74b6ac043b77a279a8f2ebd8685f0ebaa6e58c9e32e92051d529bc0baf8
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:3.4.8":
+  version: 3.4.8
+  resolution: "dompurify@npm:3.4.8"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/8f56a53d0ac80c76068772c9b72721f31fad68cac64a528e2420699ce2bd26b3516e29a5a7bd2205c2732d7114b9859998bf922d20cdb9361c4a05dab8352570
   languageName: node
   linkType: hard
 
@@ -18148,13 +18148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"monaco-editor@npm:0.55.1":
-  version: 0.55.1
-  resolution: "monaco-editor@npm:0.55.1"
+"monaco-editor@npm:0.56.0":
+  version: 0.56.0
+  resolution: "monaco-editor@npm:0.56.0"
   dependencies:
-    dompurify: "npm:3.2.7"
+    dompurify: "npm:3.4.8"
     marked: "npm:14.0.0"
-  checksum: 10c0/c1a0cf887657b42c8996518bc5ee96bbd39c977f862d2a2b2018427c45f14b0dd25d1452278202056f6b1ead97981282ccacd7d7ad918d8f0ef084159f974a25
+  checksum: 10c0/8ed728880042c5a1f42040f955e017b798fc1602fc59ef7a1f0e4da8f354e928b32cc0dba93ff677c538a37a542be3898210f9d1801f339e3c0f65f9ad3dc73e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates Monaco Editor to 0.56.0 and replaces imports of internal ESM implementation files with its supported public API. The custom go-to-definition opener now uses `editor.registerEditorOpener`.