### PR TITLE
cicd: validate Linux Homebrew release asset

### DIFF
--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -19,7 +19,7 @@ jobs:
           LINUX_ASSET="flora-${VERSION}-linux-x64.tar.gz"
           RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
 
-          curl --fail --location --retry 3 \
+          curl --fail --location --proto '=https' --proto-redir '=https' --retry 3 \
             --output "/tmp/${LINUX_ASSET}" \
             "${RELEASE_URL}/${LINUX_ASSET}"
           tar -tzf "/tmp/${LINUX_ASSET}" | awk -F/ '$NF == "flora" { found = 1 } END { exit !found }'

--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -15,6 +15,15 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           : "${HOMEBREW_TAP_TOKEN:?Set the HOMEBREW_TAP_TOKEN repository secret}"
+          VERSION="${RELEASE_TAG#v}"
+          LINUX_ASSET="flora-${VERSION}-linux-x64.tar.gz"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
+
+          curl --fail --location --retry 3 \
+            --output "/tmp/${LINUX_ASSET}" \
+            "${RELEASE_URL}/${LINUX_ASSET}"
+          tar -tzf "/tmp/${LINUX_ASSET}" | awk -F/ '$NF == "flora" { found = 1 } END { exit !found }'
+
           curl --fail-with-body --request POST \
             --header "Accept: application/vnd.github+json" \
             --header "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \


### PR DESCRIPTION
## Summary

- Validate the Linux Homebrew tarball before notifying the tap.
- Confirm the archive contains the `flora` executable.

## Why

The Homebrew cask depends on the Linux x86_64 tarball. Failing before dispatch prevents the tap from opening an update PR for an incomplete or malformed release.

## Validation

- `git diff --check`
- Workflow YAML parsed successfully

This PR contains only the Homebrew workflow change.